### PR TITLE
Release/0.3.1

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
 	"lock": true,
 
 	"name": "@oneiriq/surql",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"license": "MIT",
 	"exports": "./mod.ts",
 

--- a/examples/advancedMapping.ts
+++ b/examples/advancedMapping.ts
@@ -142,7 +142,7 @@ try {
   /**
    * Using a serializer, we reduce boilerplate and improve maintainability.
    *
-   * ✅ WORKS in both Node.js and Deno - explicit type parameters provided:
+   * WORKS in both Node.js and Deno - explicit type parameters provided:
    */
   const serializer = createSerializer()
   const postB = await client.query<PostRaw, Serialized<PostRaw>>('posts')
@@ -169,7 +169,7 @@ try {
 
   if (!postB) { throw new Error('No published posts found') }
 
-  // ✅ Explicit type parameters ensure Node.js compatibility
+  // Explicit type parameters ensure Node.js compatibility
   const author = await client.query<AuthorRaw, Serialized<AuthorRaw>>('users')
     .where({ id: postB.authorId })
     .map((raw: AuthorRaw): Serialized<AuthorRaw> => ({
@@ -182,7 +182,7 @@ try {
 
   if (!author) { throw new Error('Author not found for the post') }
 
-  // ✅ Using explicit types with a separate mapper function
+  // Using explicit types with a separate mapper function
   const comments = await client.query<CommentRaw, Comment>('comments')
     .where({ postId: postB.id })
     .map(mapComment)

--- a/examples/advancedMapping.ts
+++ b/examples/advancedMapping.ts
@@ -110,6 +110,9 @@ try {
   /**
    *  The post constant uses manual transforms in an attempt to adhere to the defined model.
    *  It's noisy and error-prone, especially with nested structures.
+   *
+   *  IMPORTANT: Explicit type parameters <PostRaw, Post> are required for Node.js compatibility.
+   *  Without them, Node.js TypeScript only infers the minimal constraint { id: RecordId }.
    * */
   const postA = await client.query<PostRaw, Post>('posts')
     .where({ published: true })
@@ -136,7 +139,11 @@ try {
   if (!postA) { throw new Error('No published posts found') }
 
 
-  /** Using a serializer, we reduce boilerplate and improve maintainability */
+  /**
+   * Using a serializer, we reduce boilerplate and improve maintainability.
+   *
+   * ✅ WORKS in both Node.js and Deno - explicit type parameters provided:
+   */
   const serializer = createSerializer()
   const postB = await client.query<PostRaw, Serialized<PostRaw>>('posts')
     .where({ published: true })
@@ -162,6 +169,7 @@ try {
 
   if (!postB) { throw new Error('No published posts found') }
 
+  // ✅ Explicit type parameters ensure Node.js compatibility
   const author = await client.query<AuthorRaw, Serialized<AuthorRaw>>('users')
     .where({ id: postB.authorId })
     .map((raw: AuthorRaw): Serialized<AuthorRaw> => ({
@@ -174,6 +182,7 @@ try {
 
   if (!author) { throw new Error('Author not found for the post') }
 
+  // ✅ Using explicit types with a separate mapper function
   const comments = await client.query<CommentRaw, Comment>('comments')
     .where({ postId: postB.id })
     .map(mapComment)

--- a/examples/customMapping.ts
+++ b/examples/customMapping.ts
@@ -48,9 +48,17 @@ const mapUser = (user: User): SerializedUser & {
   age: new Date().getFullYear() - user.birth_year
 })
 
+// IMPORTANT: Explicit type parameters are required for Node.js compatibility
+// Node.js TypeScript only infers the minimal constraint `{ id: RecordId }` without explicit generics
+// WORKS in both Node.js and Deno:
 const users = await query<User, SerializedUser & { age: number }>(conn, 'user_account')
   .map(mapUser)
   .execute()
+
+// FAILS in Node.js (TypeScript inference issue):
+// const users = await query(conn, 'user_account')
+//   .map(mapUser)  // Type error: mapUser expects User, but TypeScript infers only { id: RecordId }
+//   .execute()
 
 console.log('Users with Age (Using Serializer):', users)
 

--- a/examples/scratch.ts
+++ b/examples/scratch.ts
@@ -1,0 +1,34 @@
+import { Serialized, createSerializer, RecordId, query, SurQLClient } from "@oneiriq/surql";
+
+const client = new SurQLClient({
+    host: '10.0.0.110',
+    namespace: 'oneiric',
+    database: 'resume',
+    username: 'test',
+    password: '0mel3tte',
+    protocol: 'http',
+    port: '8080',
+    useSSL: false,
+});
+
+interface Tag {
+    id: RecordId
+    description: string
+    name: string
+}
+
+type SerializedTag = Serialized<Tag>
+const serializer = createSerializer<Tag>()
+
+const mapTag = (raw: Tag): Serialized<Tag> => ({
+    id: serializer.id(raw),
+    description: raw.description,
+    name: raw.name,
+})
+
+
+client.query<Tag, SerializedTag>('tag').map(mapTag).execute().then((res) => {
+    console.log(res);
+}).catch((e) => {
+    console.error('Error executing query:', e);
+});

--- a/src/crud/read.ts
+++ b/src/crud/read.ts
@@ -236,7 +236,6 @@ export class ReadQL<R extends { id: RecordId }, T = unknown> extends QueryBuilde
    */
   having(conditionOrField: string, operator?: Op, value?: unknown): this {
     if (operator !== undefined && value !== undefined) {
-      this.validateFieldName(conditionOrField)
       const paramName = `h${this.havingConditions.length}`
       this.params[paramName] = value
       this.havingConditions.push(`${conditionOrField} ${operator} $${paramName}`)


### PR DESCRIPTION
- Adds Node.js type inferencing documentation for npm users
- Fixes `.having()` function to allow for `surrealql` function calls (e.g. `COUNT(property)`)