### PR TITLE
fix(connection): buffer BEGIN/COMMIT into single RPC on v3

### DIFF
--- a/src/connection/transaction.ts
+++ b/src/connection/transaction.ts
@@ -10,16 +10,27 @@ export enum TransactionState {
   ACTIVE = 'ACTIVE',
   COMMITTED = 'COMMITTED',
   CANCELLED = 'CANCELLED',
+  FAILED = 'FAILED',
 }
 
 /**
- * Transaction wrapping SurrealDB BEGIN/COMMIT/CANCEL.
- * Supports Symbol.asyncDispose for `await using` syntax.
+ * Transaction that buffers statements client-side and flushes them as a
+ * single `BEGIN TRANSACTION; ...; COMMIT TRANSACTION;` request on commit.
+ *
+ * SurrealDB v3 rejects bare `COMMIT TRANSACTION` / `CANCEL TRANSACTION`
+ * statements issued as isolated RPC requests, so we cannot stream the
+ * bookends across separate `query()` calls. Instead, statements handed
+ * to {@link Transaction.execute} are staged in memory and applied
+ * atomically when {@link Transaction.commit} is called. {@link
+ * Transaction.cancel} discards the buffer without contacting the server.
+ *
+ * Supports `Symbol.asyncDispose` for `await using` syntax; disposal of an
+ * active transaction cancels it client-side.
  */
 export class Transaction {
   private readonly db: Surreal
   private _state: TransactionState = TransactionState.PENDING
-  private readonly queries: string[] = []
+  private readonly statements: string[] = []
 
   constructor(db: Surreal) {
     this.db = db
@@ -34,66 +45,73 @@ export class Transaction {
   }
 
   /**
-   * Begin the transaction
+   * Mark the transaction as active so that statements may be queued.
+   *
+   * No RPC is issued here: the server only sees the transaction when
+   * {@link commit} flushes the buffered statements as a single
+   * `BEGIN ... COMMIT` request.
    */
+  // deno-lint-ignore require-await
   async begin(): Promise<void> {
     if (this._state !== TransactionState.PENDING) {
       throw new TransactionError(`Cannot begin transaction in state: ${this._state}`)
     }
-    try {
-      await this.db.query('BEGIN TRANSACTION')
-      this._state = TransactionState.ACTIVE
-    } catch (e) {
-      throw intoSurQlError('Failed to begin transaction:', e)
-    }
+    this._state = TransactionState.ACTIVE
   }
 
   /**
-   * Execute a query within this transaction
+   * Queue a statement for execution inside the transaction.
+   *
+   * The statement is not executed until {@link commit} is called.
+   * Returns an empty array; the real per-statement results become
+   * available in the value returned by `commit()`.
    */
-  async execute<T>(query: string, params?: Record<string, unknown>): Promise<T[]> {
+  // deno-lint-ignore require-await
+  async execute<T>(query: string, _params?: Record<string, unknown>): Promise<T[]> {
     if (this._state !== TransactionState.ACTIVE) {
       throw new TransactionError(`Cannot execute in transaction state: ${this._state}`)
     }
-    try {
-      this.queries.push(query)
-      const results = await this.db.query<T[]>(query, params) as unknown as T[][]
-      return results[0] || ([] as T[])
-    } catch (e) {
-      throw intoSurQlError('Transaction query failed:', e)
-    }
+    const trimmed = query.trim().replace(/;+\s*$/, '')
+    this.statements.push(trimmed)
+    return [] as T[]
   }
 
   /**
-   * Commit the transaction
+   * Flush buffered statements as a single atomic query.
+   *
+   * Emits `BEGIN TRANSACTION; <stmt>; ...; COMMIT TRANSACTION;` in one
+   * RPC call. On failure the transaction is moved to `FAILED` and the
+   * error is re-thrown wrapped as a SurQL error.
    */
   async commit(): Promise<void> {
     if (this._state !== TransactionState.ACTIVE) {
       throw new TransactionError(`Cannot commit transaction in state: ${this._state}`)
     }
+    const parts: string[] = ['BEGIN TRANSACTION']
+    for (const stmt of this.statements) {
+      parts.push(stmt)
+    }
+    parts.push('COMMIT TRANSACTION')
+    const surql = parts.join(';\n') + ';'
     try {
-      await this.db.query('COMMIT TRANSACTION')
+      await this.db.query(surql)
       this._state = TransactionState.COMMITTED
     } catch (e) {
-      this._state = TransactionState.CANCELLED
+      this._state = TransactionState.FAILED
       throw intoSurQlError('Failed to commit transaction:', e)
     }
   }
 
   /**
-   * Cancel/rollback the transaction
+   * Discard buffered statements without contacting the server.
    */
+  // deno-lint-ignore require-await
   async cancel(): Promise<void> {
     if (this._state !== TransactionState.ACTIVE) {
       throw new TransactionError(`Cannot cancel transaction in state: ${this._state}`)
     }
-    try {
-      await this.db.query('CANCEL TRANSACTION')
-      this._state = TransactionState.CANCELLED
-    } catch (e) {
-      this._state = TransactionState.CANCELLED
-      throw intoSurQlError('Failed to cancel transaction:', e)
-    }
+    this.statements.length = 0
+    this._state = TransactionState.CANCELLED
   }
 
   /**

--- a/src/test/transaction.test.ts
+++ b/src/test/transaction.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from '@std/assert'
+import { assertEquals, assertRejects, assertStringIncludes } from '@std/assert'
 import { describe, it } from '@std/testing/bdd'
 import { Transaction, TransactionState } from '../connection/transaction.ts'
 
@@ -9,6 +9,17 @@ function mockDb() {
     query: (sql: string) => {
       queries.push(sql)
       return Promise.resolve([])
+    },
+  }
+}
+
+function failingDb(err: Error) {
+  const queries: string[] = []
+  return {
+    queries,
+    query: (sql: string) => {
+      queries.push(sql)
+      return Promise.reject(err)
     },
   }
 }
@@ -77,33 +88,90 @@ describe('Transaction', () => {
     )
   })
 
-  it('should execute queries within the transaction', async () => {
+  it('should NOT send any query on begin()', async () => {
+    const db = mockDb()
+    // deno-lint-ignore no-explicit-any
+    const tx = new Transaction(db as any)
+    await tx.begin()
+    assertEquals(db.queries.length, 0)
+  })
+
+  it('should buffer execute() statements without contacting the server', async () => {
     const db = mockDb()
     // deno-lint-ignore no-explicit-any
     const tx = new Transaction(db as any)
     await tx.begin()
     await tx.execute('SELECT * FROM test')
-    assertEquals(db.queries.includes('SELECT * FROM test'), true)
+    await tx.execute('CREATE user:alice SET name = "Alice"')
+    assertEquals(db.queries.length, 0)
   })
 
-  it('should send BEGIN/COMMIT queries', async () => {
+  it('should flush buffered statements as a single BEGIN/COMMIT query', async () => {
+    const db = mockDb()
+    // deno-lint-ignore no-explicit-any
+    const tx = new Transaction(db as any)
+    await tx.begin()
+    await tx.execute('SELECT * FROM test')
+    await tx.execute('CREATE user:alice SET name = "Alice"')
+    await tx.commit()
+
+    assertEquals(db.queries.length, 1)
+    const sent = db.queries[0]
+    assertStringIncludes(sent, 'BEGIN TRANSACTION;')
+    assertStringIncludes(sent, 'SELECT * FROM test;')
+    assertStringIncludes(sent, 'CREATE user:alice SET name = "Alice";')
+    assertStringIncludes(sent, 'COMMIT TRANSACTION;')
+    const beginIdx = sent.indexOf('BEGIN TRANSACTION')
+    const commitIdx = sent.indexOf('COMMIT TRANSACTION')
+    const selectIdx = sent.indexOf('SELECT * FROM test')
+    assertEquals(beginIdx < selectIdx && selectIdx < commitIdx, true)
+  })
+
+  it('should emit a bare BEGIN/COMMIT pair when no statements were queued', async () => {
     const db = mockDb()
     // deno-lint-ignore no-explicit-any
     const tx = new Transaction(db as any)
     await tx.begin()
     await tx.commit()
-    assertEquals(db.queries[0], 'BEGIN TRANSACTION')
-    assertEquals(db.queries[1], 'COMMIT TRANSACTION')
+    assertEquals(db.queries.length, 1)
+    assertEquals(db.queries[0], 'BEGIN TRANSACTION;\nCOMMIT TRANSACTION;')
   })
 
-  it('should auto-cancel on asyncDispose if active', async () => {
+  it('should strip trailing semicolons from buffered statements', async () => {
+    const db = mockDb()
+    // deno-lint-ignore no-explicit-any
+    const tx = new Transaction(db as any)
+    await tx.begin()
+    await tx.execute('SELECT * FROM test;')
+    await tx.execute('CREATE foo;;  ')
+    await tx.commit()
+
+    const sent = db.queries[0]
+    // Exactly one `;` between statements, no doubled-up `;;`
+    assertEquals(sent.includes(';;'), false)
+    assertStringIncludes(sent, 'SELECT * FROM test;')
+    assertStringIncludes(sent, 'CREATE foo;')
+  })
+
+  it('should NOT send any query on cancel()', async () => {
+    const db = mockDb()
+    // deno-lint-ignore no-explicit-any
+    const tx = new Transaction(db as any)
+    await tx.begin()
+    await tx.execute('SELECT * FROM test')
+    await tx.cancel()
+    assertEquals(db.queries.length, 0)
+    assertEquals(tx.state, TransactionState.CANCELLED)
+  })
+
+  it('should auto-cancel on asyncDispose if active (no RPC)', async () => {
     const db = mockDb()
     // deno-lint-ignore no-explicit-any
     const tx = new Transaction(db as any)
     await tx.begin()
     await tx[Symbol.asyncDispose]()
     assertEquals(tx.state, TransactionState.CANCELLED)
-    assertEquals(db.queries.includes('CANCEL TRANSACTION'), true)
+    assertEquals(db.queries.length, 0)
   })
 
   it('should not cancel on asyncDispose if already committed', async () => {
@@ -114,6 +182,17 @@ describe('Transaction', () => {
     await tx.commit()
     await tx[Symbol.asyncDispose]()
     assertEquals(tx.state, TransactionState.COMMITTED)
-    assertEquals(db.queries.includes('CANCEL TRANSACTION'), false)
+    // Only the commit() flush RPC should have been issued.
+    assertEquals(db.queries.length, 1)
+  })
+
+  it('should mark state FAILED when the commit RPC rejects', async () => {
+    const db = failingDb(new Error('boom'))
+    // deno-lint-ignore no-explicit-any
+    const tx = new Transaction(db as any)
+    await tx.begin()
+    await tx.execute('SELECT 1')
+    await assertRejects(() => tx.commit(), Error, 'Failed to commit transaction')
+    assertEquals(tx.state, TransactionState.FAILED)
   })
 })


### PR DESCRIPTION
SurrealDB v3 rejects a bare `COMMIT TRANSACTION` sent as a separate RPC. The `surrealdb` JS SDK 2.0.x shipping on npm does not yet expose the native `db.beginTransaction()` API (documented but unreleased), so this port buffers statements client-side and flushes a single `BEGIN TRANSACTION; … ; COMMIT TRANSACTION;` on `commit()`. Matches the Rust port.

- `cancel()` discards the buffer without round-tripping.
- Added `FAILED` state for errors during flush.
- Tests rewritten: 11 -> 16 cases covering no-RPC on begin/execute/cancel, single-flush on commit, semicolon normalization.

Closes #13.