### PR TITLE
fix(ci): pin integration workflow to SurrealDB v3.0.5

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,7 +23,7 @@ jobs:
           docker run -d \
             --name surrealdb \
             -p 8000:8000 \
-            surrealdb/surrealdb:latest \
+            surrealdb/surrealdb:v3.0.5 \
             start --user root --pass root memory
           for i in $(seq 1 20); do
             if curl -sf http://localhost:8000/health; then


### PR DESCRIPTION
`.github/workflows/integration.yml:26` — `surrealdb/surrealdb:latest` -> `surrealdb/surrealdb:v3.0.5`. Matches rs/go/py CI and makes v3 behaviour verifiable across upstream image rebuilds.

Audited all workflows; this was the only `:latest` reference.

Closes #14.