### PR TITLE
fix(schema): add IF NOT EXISTS emitter for DEFINE TABLE / DEFINE ACCESS

### DIFF
--- a/src/schema/sql.ts
+++ b/src/schema/sql.ts
@@ -79,12 +79,18 @@ function generateEventSql(tableName: string, evt: EventDefinition): string {
 }
 
 /**
- * Generate SurrealQL DDL for a table definition
+ * Generate SurrealQL DDL for a table definition.
+ *
+ * Pass `ifNotExists: true` to emit `DEFINE TABLE IF NOT EXISTS ...` so the
+ * statement is idempotent against an existing schema. The flag also applies
+ * to the secondary `DEFINE TABLE ... PERMISSIONS` line when table-level
+ * permissions are configured.
  */
-export function generateTableSql(table: TableDefinition): string {
+export function generateTableSql(table: TableDefinition, options: { ifNotExists?: boolean } = {}): string {
+  const ine = options.ifNotExists ? ' IF NOT EXISTS' : ''
   const lines: string[] = []
 
-  lines.push(`DEFINE TABLE ${table.name} ${table.mode};`)
+  lines.push(`DEFINE TABLE${ine} ${table.name} ${table.mode};`)
 
   for (const field of table.fields) {
     lines.push(generateFieldSql(table.name, field))
@@ -105,7 +111,7 @@ export function generateTableSql(table: TableDefinition): string {
     if (table.permissions.update) perms.push(`FOR update ${table.permissions.update}`)
     if (table.permissions.delete) perms.push(`FOR delete ${table.permissions.delete}`)
     if (perms.length > 0) {
-      lines.push(`DEFINE TABLE ${table.name} PERMISSIONS ${perms.join(', ')};`)
+      lines.push(`DEFINE TABLE${ine} ${table.name} PERMISSIONS ${perms.join(', ')};`)
     }
   }
 
@@ -113,12 +119,16 @@ export function generateTableSql(table: TableDefinition): string {
 }
 
 /**
- * Generate SurrealQL DDL for an edge definition
+ * Generate SurrealQL DDL for an edge definition.
+ *
+ * Pass `ifNotExists: true` to emit `DEFINE TABLE IF NOT EXISTS ... TYPE RELATION`
+ * for idempotent schema application.
  */
-export function generateEdgeSql(edge: EdgeDefinition): string {
+export function generateEdgeSql(edge: EdgeDefinition, options: { ifNotExists?: boolean } = {}): string {
+  const ine = options.ifNotExists ? ' IF NOT EXISTS' : ''
   const lines: string[] = []
 
-  let tableDef = `DEFINE TABLE ${edge.name} TYPE ${edge.mode}`
+  let tableDef = `DEFINE TABLE${ine} ${edge.name} TYPE ${edge.mode}`
   if (edge.fromTable) tableDef += ` FROM ${edge.fromTable}`
   if (edge.toTable) tableDef += ` TO ${edge.toTable}`
   lines.push(tableDef + ';')
@@ -139,11 +149,19 @@ export function generateEdgeSql(edge: EdgeDefinition): string {
 }
 
 /**
- * Generate SurrealQL DDL for an access definition
+ * Generate SurrealQL DDL for an access definition.
+ *
+ * Pass `ifNotExists: true` to emit `DEFINE ACCESS IF NOT EXISTS ...` so the
+ * statement can be re-run safely.
  */
-export function generateAccessSql(access: AccessDefinition, level: string = 'DATABASE'): string {
+export function generateAccessSql(
+  access: AccessDefinition,
+  level: string = 'DATABASE',
+  options: { ifNotExists?: boolean } = {},
+): string {
+  const ine = options.ifNotExists ? ' IF NOT EXISTS' : ''
   if (access.type === AccessType.JWT && access.jwt) {
-    let sql = `DEFINE ACCESS ${access.name} ON ${level} TYPE JWT`
+    let sql = `DEFINE ACCESS${ine} ${access.name} ON ${level} TYPE JWT`
     sql += ` ALGORITHM ${access.jwt.algorithm}`
     sql += ` KEY '${access.jwt.key}'`
     if (access.jwt.issuer) sql += ` WITH ISSUER '${access.jwt.issuer}'`
@@ -151,40 +169,45 @@ export function generateAccessSql(access: AccessDefinition, level: string = 'DAT
   }
 
   if (access.type === AccessType.RECORD && access.record) {
-    let sql = `DEFINE ACCESS ${access.name} ON ${level} TYPE RECORD`
+    let sql = `DEFINE ACCESS${ine} ${access.name} ON ${level} TYPE RECORD`
     if (access.record.signup) sql += ` SIGNUP (${access.record.signup})`
     if (access.record.signin) sql += ` SIGNIN (${access.record.signin})`
     return sql + ';'
   }
 
-  return `DEFINE ACCESS ${access.name} ON ${level} TYPE ${access.type};`
+  return `DEFINE ACCESS${ine} ${access.name} ON ${level} TYPE ${access.type};`
 }
 
 /**
- * Generate all schema SQL from tables, edges, and access definitions
+ * Generate all schema SQL from tables, edges, and access definitions.
+ *
+ * Pass `ifNotExists: true` to propagate `IF NOT EXISTS` to every emitted
+ * `DEFINE TABLE` and `DEFINE ACCESS` statement.
  */
 export function generateSchemaSql(options: {
   tables?: TableDefinition[]
   edges?: EdgeDefinition[]
   access?: AccessDefinition[]
+  ifNotExists?: boolean
 }): string {
   const parts: string[] = []
+  const emitOpts = { ifNotExists: options.ifNotExists }
 
   if (options.tables) {
     for (const table of options.tables) {
-      parts.push(generateTableSql(table))
+      parts.push(generateTableSql(table, emitOpts))
     }
   }
 
   if (options.edges) {
     for (const edge of options.edges) {
-      parts.push(generateEdgeSql(edge))
+      parts.push(generateEdgeSql(edge, emitOpts))
     }
   }
 
   if (options.access) {
     for (const acc of options.access) {
-      parts.push(generateAccessSql(acc))
+      parts.push(generateAccessSql(acc, 'DATABASE', emitOpts))
     }
   }
 

--- a/src/test/schema.test.ts
+++ b/src/test/schema.test.ts
@@ -27,6 +27,7 @@ import {
   withFields,
   withFromTable,
   withIndexes,
+  withPermissions,
   withToTable,
 } from '../schema/mod.ts'
 
@@ -150,6 +151,55 @@ describe('Schema System', () => {
       const sql = generateSchemaSql({ tables, edges })
       assertStringIncludes(sql, 'DEFINE TABLE users')
       assertStringIncludes(sql, 'DEFINE TABLE follows')
+    })
+
+    it('should emit DEFINE TABLE IF NOT EXISTS when ifNotExists is true', () => {
+      const t = withFields(tableSchema('users'), stringField('name'))
+      const sql = generateTableSql(t, { ifNotExists: true })
+      assertStringIncludes(sql, 'DEFINE TABLE IF NOT EXISTS users SCHEMAFULL')
+      // Field/index/event sub-statements are unaffected by the table flag.
+      assertStringIncludes(sql, 'DEFINE FIELD name ON TABLE users TYPE string')
+    })
+
+    it('should omit IF NOT EXISTS by default on DEFINE TABLE', () => {
+      const t = tableSchema('users')
+      const sql = generateTableSql(t)
+      assertEquals(sql.includes('IF NOT EXISTS'), false)
+    })
+
+    it('should apply IF NOT EXISTS to the secondary permissions DEFINE TABLE line', () => {
+      const t = withPermissions(tableSchema('users'), { select: 'WHERE user = $auth' })
+      const sql = generateTableSql(t, { ifNotExists: true })
+      // Both the primary and the permissions line must carry IF NOT EXISTS.
+      const occurrences = sql.match(/DEFINE TABLE IF NOT EXISTS users/g) ?? []
+      assertEquals(occurrences.length, 2)
+      assertStringIncludes(sql, 'PERMISSIONS FOR select WHERE user = $auth')
+    })
+
+    it('should emit DEFINE TABLE IF NOT EXISTS ... TYPE RELATION for edges', () => {
+      const e = withToTable(withFromTable(edgeSchema('follows'), 'users'), 'users')
+      const sql = generateEdgeSql(e, { ifNotExists: true })
+      assertStringIncludes(sql, 'DEFINE TABLE IF NOT EXISTS follows TYPE RELATION FROM users TO users')
+    })
+
+    it('should omit IF NOT EXISTS by default on DEFINE TABLE (edge)', () => {
+      const e = edgeSchema('follows')
+      const sql = generateEdgeSql(e)
+      assertEquals(sql.includes('IF NOT EXISTS'), false)
+    })
+
+    it('should propagate ifNotExists through generateSchemaSql', () => {
+      const tables = [withFields(tableSchema('users'), stringField('name'))]
+      const edges = [typedEdge('follows', 'users', 'users')]
+      const sql = generateSchemaSql({ tables, edges, ifNotExists: true })
+      assertStringIncludes(sql, 'DEFINE TABLE IF NOT EXISTS users')
+      assertStringIncludes(sql, 'DEFINE TABLE IF NOT EXISTS follows')
+    })
+
+    it('should not emit IF NOT EXISTS from generateSchemaSql by default', () => {
+      const tables = [withFields(tableSchema('users'), stringField('name'))]
+      const sql = generateSchemaSql({ tables })
+      assertEquals(sql.includes('IF NOT EXISTS'), false)
     })
   })
 

--- a/src/test/schema_access.test.ts
+++ b/src/test/schema_access.test.ts
@@ -1,6 +1,7 @@
-import { assertEquals } from '@std/assert'
+import { assertEquals, assertStringIncludes } from '@std/assert'
 import { describe, it } from '@std/testing/bdd'
 import { accessSchema, AccessType, jwtAccess, recordAccess } from '../schema/access.ts'
+import { generateAccessSql } from '../schema/sql.ts'
 
 describe('AccessType enum', () => {
   it('should have JWT and RECORD values', () => {
@@ -75,5 +76,41 @@ describe('recordAccess', () => {
   it('should return a frozen object', () => {
     const result = recordAccess('frozen_rec', {})
     assertEquals(Object.isFrozen(result), true)
+  })
+})
+
+describe('generateAccessSql', () => {
+  it('should emit DEFINE ACCESS without IF NOT EXISTS by default (JWT)', () => {
+    const access = jwtAccess('my_jwt', { algorithm: 'HS256', key: 'secret' })
+    const sql = generateAccessSql(access)
+    assertStringIncludes(sql, 'DEFINE ACCESS my_jwt ON DATABASE TYPE JWT')
+    assertEquals(sql.includes('IF NOT EXISTS'), false)
+  })
+
+  it('should emit DEFINE ACCESS IF NOT EXISTS when flag is set (JWT)', () => {
+    const access = jwtAccess('my_jwt', { algorithm: 'HS256', key: 'secret' })
+    const sql = generateAccessSql(access, 'DATABASE', { ifNotExists: true })
+    assertStringIncludes(sql, 'DEFINE ACCESS IF NOT EXISTS my_jwt ON DATABASE TYPE JWT')
+    assertStringIncludes(sql, "ALGORITHM HS256 KEY 'secret'")
+  })
+
+  it('should emit DEFINE ACCESS IF NOT EXISTS when flag is set (RECORD)', () => {
+    const access = recordAccess('my_rec', { signup: 'CREATE user', signin: 'SELECT * FROM user' })
+    const sql = generateAccessSql(access, 'DATABASE', { ifNotExists: true })
+    assertStringIncludes(sql, 'DEFINE ACCESS IF NOT EXISTS my_rec ON DATABASE TYPE RECORD')
+    assertStringIncludes(sql, 'SIGNUP (CREATE user)')
+    assertStringIncludes(sql, 'SIGNIN (SELECT * FROM user)')
+  })
+
+  it('should emit DEFINE ACCESS IF NOT EXISTS when flag is set (bare access)', () => {
+    const access = accessSchema('my_jwt', AccessType.JWT)
+    const sql = generateAccessSql(access, 'DATABASE', { ifNotExists: true })
+    assertStringIncludes(sql, 'DEFINE ACCESS IF NOT EXISTS my_jwt ON DATABASE TYPE JWT')
+  })
+
+  it('should respect the custom level argument with ifNotExists', () => {
+    const access = jwtAccess('ns_jwt', { algorithm: 'HS256', key: 'k' })
+    const sql = generateAccessSql(access, 'NAMESPACE', { ifNotExists: true })
+    assertStringIncludes(sql, 'DEFINE ACCESS IF NOT EXISTS ns_jwt ON NAMESPACE TYPE JWT')
   })
 })


### PR DESCRIPTION
`generateTableSql`, `generateEdgeSql`, `generateAccessSql`, `generateSchemaSql` gain an opt-in `ifNotExists?: boolean` parameter (default `false`). When true, emits `DEFINE TABLE IF NOT EXISTS …` (and propagates to the secondary `PERMISSIONS` line). Matches py/rs/go, which all expose the same opt-in.

+12 new test steps in schema.test.ts / schema_access.test.ts.

Closes #15.