### PR TITLE
feat(schema): port structured DEFINE parser from py/rs/go

### DIFF
--- a/src/schema/access.ts
+++ b/src/schema/access.ts
@@ -11,7 +11,8 @@ export enum AccessType {
  */
 export interface JwtConfig {
   readonly algorithm: string
-  readonly key: string
+  readonly key?: string
+  readonly url?: string
   readonly issuer?: string
   readonly audience?: string
 }
@@ -33,6 +34,8 @@ export interface AccessDefinition {
   readonly type: AccessType
   readonly jwt?: JwtConfig
   readonly record?: RecordAccessConfig
+  readonly durationSession?: string
+  readonly durationToken?: string
 }
 
 /** Create a generic access schema */

--- a/src/schema/mod.ts
+++ b/src/schema/mod.ts
@@ -39,12 +39,21 @@ export {
   stringField,
 } from './fields.ts'
 export {
+  type DatabaseInfo,
   fetchDbInfo,
   fetchTableInfo,
+  parseAccess,
   parseDbInfo,
-  type ParsedDbInfo,
-  type ParsedTableInfo,
+  parseEdgeInfo,
+  parseEvent,
+  parseEvents,
+  parseField,
+  parseFields,
+  parseIndex,
+  parseIndexes,
   parseTableInfo,
+  parseTableMode,
+  SchemaParseError,
 } from './parser.ts'
 export {
   clearRegistry,
@@ -59,6 +68,8 @@ export { generateAccessSql, generateEdgeSql, generateSchemaSql, generateTableSql
 export {
   event,
   type EventDefinition,
+  HnswDistanceType,
+  hnswIndex,
   index,
   type IndexDefinition,
   IndexType,

--- a/src/schema/parser.ts
+++ b/src/schema/parser.ts
@@ -1,75 +1,765 @@
+/**
+ * Database schema parser.
+ *
+ * Parses SurrealDB `INFO FOR DB` / `INFO FOR TABLE` responses back into
+ * structured `TableDefinition`, `EdgeDefinition`, `FieldDefinition`,
+ * `IndexDefinition`, `EventDefinition`, and `AccessDefinition` values.
+ *
+ * 1:1 port of:
+ * - `surql-py/src/surql/schema/parser.py`
+ * - `surql-rs/src/schema/parser.rs`
+ * - `surql-go/pkg/surql/schema/parser.go`
+ *
+ * Accepts both shapes the server can return:
+ * - long-key maps (`fields`, `indexes`, `events`, `tables`, `accesses`)
+ * - short-key maps (`fd`, `ix`, `ev`, `tb`, `ac`) as observed from SurrealDB v1.
+ */
+
 import type { Surreal } from 'surrealdb'
 import { intoSurQlError } from '../utils/surrealError.ts'
+import type { AccessDefinition, JwtConfig, RecordAccessConfig } from './access.ts'
+import { AccessType } from './access.ts'
+import type { EdgeDefinition } from './edge.ts'
+import { EdgeMode } from './edge.ts'
+import type { FieldDefinition } from './fields.ts'
+import { FieldType } from './fields.ts'
+import type { EventDefinition, IndexDefinition, TableDefinition } from './table.ts'
+import { HnswDistanceType, IndexType, MTreeDistanceType, MTreeVectorType, TableMode } from './table.ts'
 
-/**
- * Parsed table info from INFO FOR TABLE
- */
-export interface ParsedTableInfo {
-  readonly name: string
-  readonly fields: Record<string, string>
-  readonly indexes: Record<string, string>
-  readonly events: Record<string, string>
-  readonly lives: Record<string, string>
+/** Strip `readonly` modifiers so definitions can be built incrementally. */
+type Mutable<T> = {
+  -readonly [K in keyof T]: T[K]
 }
 
-/**
- * Parsed database info from INFO FOR DB
- */
-export interface ParsedDbInfo {
-  readonly tables: Record<string, string>
-  readonly accesses: Record<string, string>
-  readonly analyzers: Record<string, string>
-  readonly functions: Record<string, string>
-  readonly params: Record<string, string>
-}
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
 
 /**
- * Parse INFO FOR TABLE response into a structured object
+ * Error raised when a SurrealDB `INFO` payload or `DEFINE` statement cannot be
+ * parsed into a structured definition.
  */
-export function parseTableInfo(raw: Record<string, unknown>): ParsedTableInfo {
-  return {
-    name: '',
-    fields: (raw.fields ?? raw.fd ?? {}) as Record<string, string>,
-    indexes: (raw.indexes ?? raw.ix ?? {}) as Record<string, string>,
-    events: (raw.events ?? raw.ev ?? {}) as Record<string, string>,
-    lives: (raw.lives ?? raw.lv ?? {}) as Record<string, string>,
+export class SchemaParseError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message)
+    this.name = 'SchemaParseError'
+    if (options?.cause !== undefined) {
+      ;(this as unknown as { cause: unknown }).cause = options.cause
+    }
   }
 }
 
+// ---------------------------------------------------------------------------
+// Public return types
+// ---------------------------------------------------------------------------
+
 /**
- * Parse INFO FOR DB response into a structured object
+ * Structured result of parsing an `INFO FOR DB` response.
+ *
+ * Tables declared with `TYPE RELATION FROM ... TO ...` are routed into
+ * `edges`; every other table becomes a `TableDefinition` in `tables`.
  */
-export function parseDbInfo(raw: Record<string, unknown>): ParsedDbInfo {
-  return {
-    tables: (raw.tables ?? raw.tb ?? {}) as Record<string, string>,
-    accesses: (raw.accesses ?? raw.ac ?? {}) as Record<string, string>,
-    analyzers: (raw.analyzers ?? raw.az ?? {}) as Record<string, string>,
-    functions: (raw.functions ?? raw.fn ?? {}) as Record<string, string>,
-    params: (raw.params ?? raw.pa ?? {}) as Record<string, string>,
-  }
+export interface DatabaseInfo {
+  readonly tables: Readonly<Record<string, TableDefinition>>
+  readonly edges: Readonly<Record<string, EdgeDefinition>>
+  readonly accesses: Readonly<Record<string, AccessDefinition>>
+}
+
+// ---------------------------------------------------------------------------
+// Keyword / clause helpers (word-boundary safe)
+// ---------------------------------------------------------------------------
+
+const IDENT_RE = /[A-Za-z0-9_]/
+const FIELD_TYPE_RE = /TYPE\s+(\w+)/i
+const READONLY_RE = /\bREADONLY\b/i
+const FLEXIBLE_RE = /\bFLEXIBLE\b/i
+const COLUMNS_RE = /COLUMNS\s+([^;]+?)(?:UNIQUE|SEARCH|HNSW|MTREE|\s*;|\s*$)/i
+const FIELDS_RE = /FIELDS\s+([^;]+?)(?:UNIQUE|SEARCH|HNSW|MTREE|\s*;|\s*$)/i
+const DIMENSION_RE = /DIMENSION\s+(\d+)/i
+const DISTANCE_RE = /(?:DIST|DISTANCE)\s+(\w+)/i
+const EFC_RE = /EFC\s+(\d+)/i
+const M_RE = /\bM\s+(\d+)/i
+const WHEN_RE = /WHEN\s+([\s\S]+?)\s+THEN/i
+const THEN_BRACE_RE = /THEN\s+\{([\s\S]+?)\}(?:\s*;|\s*$)/i
+const THEN_BARE_RE = /THEN\s+([\s\S]+?)(?:\s*;|\s*$)/i
+const RELATION_RE = /TYPE\s+RELATION\s+FROM\s+(\w+)\s+TO\s+(\w+)/i
+const ALGORITHM_RE = /ALGORITHM\s+(\w+)/i
+const KEY_RE = /KEY\s+'([^']*)'/i
+const URL_RE = /URL\s+'([^']*)'/i
+const ISSUER_RE = /WITH\s+ISSUER\s+'([^']*)'/i
+const SIGNUP_RE = /SIGNUP\s+\(([\s\S]+?)\)(?:\s+SIGNIN|\s+DURATION|\s*;|\s*$)/i
+const SIGNIN_RE = /SIGNIN\s+\(([\s\S]+?)\)(?:\s+SIGNUP|\s+DURATION|\s*;|\s*$)/i
+const SESSION_RE = /FOR\s+SESSION\s+(\w+)/i
+const TOKEN_RE = /FOR\s+TOKEN\s+(\w+)/i
+const ACCESS_TYPE_RE = /TYPE\s+(JWT|RECORD)/i
+
+/** Is this byte/char part of an identifier? */
+function isIdent(ch: string): boolean {
+  return IDENT_RE.test(ch)
 }
 
 /**
- * Fetch and parse table info from a live database
+ * Locate the case-insensitive keyword `kw` in `text`, honouring word
+ * boundaries. When `requireWhitespaceLeft` is true, the keyword must sit at
+ * position 0 or follow ASCII whitespace — this prevents a `$value` identifier
+ * from terminating a clause that is scanning for the literal `VALUE` keyword.
+ *
+ * Returns the character offset at which the keyword starts, or `-1` if not
+ * found.
  */
-export async function fetchTableInfo(db: Surreal, tableName: string): Promise<ParsedTableInfo> {
+function findKeyword(text: string, kw: string, requireWhitespaceLeft: boolean): number {
+  const textUpper = text.toUpperCase()
+  const kwUpper = kw.toUpperCase()
+  if (kwUpper.length === 0) return -1
+
+  let i = 0
+  while (i + kwUpper.length <= textUpper.length) {
+    if (textUpper.slice(i, i + kwUpper.length) === kwUpper) {
+      const leftOk = requireWhitespaceLeft
+        ? i === 0 || /\s/.test(textUpper.charAt(i - 1))
+        : i === 0 || !isIdent(textUpper.charAt(i - 1))
+      const rightEnd = i + kwUpper.length
+      const rightOk = rightEnd === textUpper.length || !isIdent(textUpper.charAt(rightEnd))
+      if (leftOk && rightOk) return i
+    }
+    i += 1
+  }
+  return -1
+}
+
+/**
+ * Extract the body of a `<KEYWORD> <body> [TERMINATOR | ;]` clause.
+ *
+ * `terminators` lists keywords that would end the clause; any such occurrence
+ * after the `keyword` anchor truncates the body. A trailing semicolon always
+ * truncates. Returns `undefined` when the clause is absent or has an empty
+ * body.
+ */
+function extractClause(definition: string, keyword: string, terminators: readonly string[]): string | undefined {
+  // Require the anchor keyword to be preceded by whitespace so the parser
+  // does not mistake `$value` / `$before` / `$after` for a clause anchor.
+  const start = findKeyword(definition, keyword, true)
+  if (start < 0) return undefined
+  const afterKw = start + keyword.length
+
+  // Require at least one whitespace after the keyword (matches `\s+`).
+  let restStart = afterKw
+  while (restStart < definition.length && /\s/.test(definition.charAt(restStart))) restStart += 1
+  if (restStart === afterKw) return undefined
+
+  const tail = definition.slice(restStart)
+
+  let end = tail.length
+  for (const term of terminators) {
+    const pos = findKeyword(tail, term, true)
+    if (pos >= 0 && pos < end) end = pos
+  }
+  const semi = tail.indexOf(';')
+  if (semi >= 0 && semi < end) end = semi
+
+  const body = tail.slice(0, end).trim()
+  if (body.length === 0) return undefined
+  return body
+}
+
+// ---------------------------------------------------------------------------
+// Input coercion helpers (INFO responses)
+// ---------------------------------------------------------------------------
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function expectObject(value: unknown, context: string): Record<string, unknown> {
+  if (!isPlainObject(value)) {
+    const typeName = value === null ? 'null' : Array.isArray(value) ? 'array' : typeof value
+    throw new SchemaParseError(`${context}: expected object, got ${typeName}`)
+  }
+  return value
+}
+
+/**
+ * Coerce a map-of-string JSON value into a `Record<string, string>`.
+ *
+ * Non-string values are skipped so callers can tolerate server responses that
+ * stash additional metadata under the same key.
+ */
+function valueToStringMap(value: unknown): Record<string, string> {
+  if (!isPlainObject(value)) return {}
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(value)) {
+    if (typeof v === 'string') out[k] = v
+  }
+  return out
+}
+
+/** Pick the first populated child object from `info` under any of `keys`. */
+function pickMap(info: Record<string, unknown>, keys: readonly string[]): Record<string, unknown> | undefined {
+  for (const k of keys) {
+    const v = info[k]
+    if (isPlainObject(v) && Object.keys(v).length > 0) return v
+  }
+  return undefined
+}
+
+function stringAt(info: Record<string, unknown>, ...keys: readonly string[]): string {
+  for (const k of keys) {
+    const v = info[k]
+    if (typeof v === 'string') return v
+  }
+  return ''
+}
+
+// ---------------------------------------------------------------------------
+// Field parsing
+// ---------------------------------------------------------------------------
+
+function extractFieldType(definition: string): FieldType {
+  const m = FIELD_TYPE_RE.exec(definition)
+  if (!m) return FieldType.ANY
+  switch (m[1].toLowerCase()) {
+    case 'string':
+      return FieldType.STRING
+    case 'int':
+      return FieldType.INT
+    case 'float':
+      return FieldType.FLOAT
+    case 'bool':
+      return FieldType.BOOL
+    case 'datetime':
+      return FieldType.DATETIME
+    case 'duration':
+      return FieldType.DURATION
+    case 'decimal':
+      return FieldType.DECIMAL
+    case 'number':
+      return FieldType.NUMBER
+    case 'object':
+      return FieldType.OBJECT
+    case 'array':
+      return FieldType.ARRAY
+    case 'record':
+      return FieldType.RECORD
+    case 'geometry':
+      return FieldType.GEOMETRY
+    default:
+      return FieldType.ANY
+  }
+}
+
+function extractAssertion(definition: string): string | undefined {
+  return extractClause(definition, 'ASSERT', ['DEFAULT', 'VALUE', 'READONLY', 'FLEXIBLE', 'PERMISSIONS'])
+}
+
+function extractDefault(definition: string): string | undefined {
+  return extractClause(definition, 'DEFAULT', ['VALUE', 'READONLY', 'FLEXIBLE', 'PERMISSIONS', 'ASSERT'])
+}
+
+function extractValue(definition: string): string | undefined {
+  return extractClause(definition, 'VALUE', ['DEFAULT', 'READONLY', 'FLEXIBLE', 'PERMISSIONS', 'ASSERT'])
+}
+
+function extractReadonly(definition: string): boolean {
+  return READONLY_RE.test(definition)
+}
+
+function extractFlexible(definition: string): boolean {
+  return FLEXIBLE_RE.test(definition)
+}
+
+/**
+ * Parse a single `DEFINE FIELD <name> ON ...` statement into a
+ * `FieldDefinition`. Returns `undefined` when the definition string is empty.
+ */
+export function parseField(name: string, definition: string): FieldDefinition | undefined {
+  if (!definition || definition.trim().length === 0) return undefined
+  const base: Mutable<FieldDefinition> = {
+    name,
+    type: extractFieldType(definition),
+  }
+  const assertion = extractAssertion(definition)
+  if (assertion !== undefined) base.assertion = assertion
+  const defaultValue = extractDefault(definition)
+  if (defaultValue !== undefined) base.defaultValue = defaultValue
+  const value = extractValue(definition)
+  if (value !== undefined) base.value = value
+  if (extractReadonly(definition)) base.readonly = true
+  if (extractFlexible(definition)) base.flexible = true
+  return Object.freeze(base) as FieldDefinition
+}
+
+/** Parse every entry of a `fd` / `fields` map into `FieldDefinition` values. */
+export function parseFields(fd: Record<string, string>): FieldDefinition[] {
+  const out: FieldDefinition[] = []
+  for (const [name, def] of Object.entries(fd)) {
+    const parsed = parseField(name, def)
+    if (parsed !== undefined) out.push(parsed)
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Index parsing
+// ---------------------------------------------------------------------------
+
+function splitColumns(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+}
+
+function extractIndexColumns(definition: string): string[] {
+  const m = COLUMNS_RE.exec(definition)
+  if (!m) return []
+  return splitColumns(m[1])
+}
+
+function extractIndexFields(definition: string): string[] {
+  const m = FIELDS_RE.exec(definition)
+  if (!m) return []
+  return splitColumns(m[1])
+}
+
+function extractIndexType(definition: string): IndexType {
+  const upper = definition.toUpperCase()
+  if (upper.includes('UNIQUE')) return IndexType.UNIQUE
+  if (upper.includes('SEARCH')) return IndexType.SEARCH
+  if (upper.includes('HNSW')) return IndexType.HNSW
+  if (upper.includes('MTREE')) return IndexType.MTREE
+  return IndexType.STANDARD
+}
+
+function extractDimension(definition: string): number | undefined {
+  const m = DIMENSION_RE.exec(definition)
+  if (!m) return undefined
+  const n = Number.parseInt(m[1], 10)
+  return Number.isNaN(n) ? undefined : n
+}
+
+function extractMtreeDistance(definition: string): MTreeDistanceType | undefined {
+  const m = DISTANCE_RE.exec(definition)
+  if (!m) return undefined
+  switch (m[1].toUpperCase()) {
+    case 'COSINE':
+      return MTreeDistanceType.COSINE
+    case 'EUCLIDEAN':
+      return MTreeDistanceType.EUCLIDEAN
+    case 'MANHATTAN':
+      return MTreeDistanceType.MANHATTAN
+    case 'MINKOWSKI':
+      return MTreeDistanceType.MINKOWSKI
+    default:
+      return undefined
+  }
+}
+
+function extractHnswDistance(definition: string): HnswDistanceType | undefined {
+  const m = DISTANCE_RE.exec(definition)
+  if (!m) return undefined
+  switch (m[1].toUpperCase()) {
+    case 'CHEBYSHEV':
+      return HnswDistanceType.CHEBYSHEV
+    case 'COSINE':
+      return HnswDistanceType.COSINE
+    case 'EUCLIDEAN':
+      return HnswDistanceType.EUCLIDEAN
+    case 'HAMMING':
+      return HnswDistanceType.HAMMING
+    case 'JACCARD':
+      return HnswDistanceType.JACCARD
+    case 'MANHATTAN':
+      return HnswDistanceType.MANHATTAN
+    case 'MINKOWSKI':
+      return HnswDistanceType.MINKOWSKI
+    case 'PEARSON':
+      return HnswDistanceType.PEARSON
+    default:
+      return undefined
+  }
+}
+
+function extractVectorType(definition: string): MTreeVectorType | undefined {
+  // MTREE/HNSW `TYPE` clauses usually appear after `MTREE` / `HNSW`. Scan every
+  // TYPE occurrence in case the first one is swallowed by the field type
+  // clause (SurrealDB uses `TYPE` twice for these indexes).
+  const re = /TYPE\s+(\w+)/gi
+  let m: RegExpExecArray | null
+  while ((m = re.exec(definition)) !== null) {
+    switch (m[1].toUpperCase()) {
+      case 'F64':
+        return MTreeVectorType.F64
+      case 'F32':
+        return MTreeVectorType.F32
+      case 'I64':
+        return MTreeVectorType.I64
+      case 'I32':
+        return MTreeVectorType.I32
+      case 'I16':
+        return MTreeVectorType.I16
+    }
+  }
+  return undefined
+}
+
+function extractHnswEfc(definition: string): number | undefined {
+  const m = EFC_RE.exec(definition)
+  if (!m) return undefined
+  const n = Number.parseInt(m[1], 10)
+  return Number.isNaN(n) ? undefined : n
+}
+
+function extractHnswM(definition: string): number | undefined {
+  const m = M_RE.exec(definition)
+  if (!m) return undefined
+  const n = Number.parseInt(m[1], 10)
+  return Number.isNaN(n) ? undefined : n
+}
+
+/**
+ * Parse a single `DEFINE INDEX <name> ON TABLE <table> ...` statement into an
+ * `IndexDefinition`. Returns `undefined` when the definition string is empty.
+ */
+export function parseIndex(name: string, definition: string): IndexDefinition | undefined {
+  if (!definition || definition.trim().length === 0) return undefined
+
+  let columns = extractIndexColumns(definition)
+  if (columns.length === 0) columns = extractIndexFields(definition)
+
+  const type = extractIndexType(definition)
+  const base: Mutable<IndexDefinition> = {
+    name,
+    fields: columns,
+    type,
+  }
+
+  if (type === IndexType.MTREE) {
+    const dim = extractDimension(definition)
+    if (dim !== undefined) base.mtreeDimension = dim
+    const dist = extractMtreeDistance(definition)
+    if (dist !== undefined) base.mtreeDistance = dist
+    const vt = extractVectorType(definition)
+    if (vt !== undefined) base.mtreeVectorType = vt
+  } else if (type === IndexType.HNSW) {
+    const dim = extractDimension(definition)
+    if (dim !== undefined) base.mtreeDimension = dim
+    const vt = extractVectorType(definition)
+    if (vt !== undefined) base.mtreeVectorType = vt
+    const dist = extractHnswDistance(definition)
+    if (dist !== undefined) base.hnswDistance = dist
+    const efc = extractHnswEfc(definition)
+    if (efc !== undefined) base.hnswEfc = efc
+    const m = extractHnswM(definition)
+    if (m !== undefined) base.hnswM = m
+  }
+
+  return Object.freeze(base)
+}
+
+/** Parse every entry of an `ix` / `indexes` map into `IndexDefinition` values. */
+export function parseIndexes(ix: Record<string, string>): IndexDefinition[] {
+  const out: IndexDefinition[] = []
+  for (const [name, def] of Object.entries(ix)) {
+    const parsed = parseIndex(name, def)
+    if (parsed !== undefined) out.push(parsed)
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Event parsing
+// ---------------------------------------------------------------------------
+
+function extractEventCondition(definition: string): string | undefined {
+  const m = WHEN_RE.exec(definition)
+  return m ? m[1].trim() : undefined
+}
+
+function extractEventAction(definition: string): string | undefined {
+  const braceMatch = THEN_BRACE_RE.exec(definition)
+  if (braceMatch) return braceMatch[1].trim()
+  const bareMatch = THEN_BARE_RE.exec(definition)
+  if (bareMatch) return bareMatch[1].trim()
+  return undefined
+}
+
+/**
+ * Parse a single `DEFINE EVENT <name> ON TABLE <t> WHEN <c> THEN <a>` statement
+ * into an `EventDefinition`. Returns `undefined` when either the condition or
+ * action cannot be located.
+ */
+export function parseEvent(name: string, definition: string): EventDefinition | undefined {
+  if (!definition || definition.trim().length === 0) return undefined
+  const when = extractEventCondition(definition)
+  const then = extractEventAction(definition)
+  if (when === undefined || then === undefined) return undefined
+  return Object.freeze({ name, when, then })
+}
+
+/** Parse every entry of an `ev` / `events` map into `EventDefinition` values. */
+export function parseEvents(ev: Record<string, string>): EventDefinition[] {
+  const out: EventDefinition[] = []
+  for (const [name, def] of Object.entries(ev)) {
+    const parsed = parseEvent(name, def)
+    if (parsed !== undefined) out.push(parsed)
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Access parsing
+// ---------------------------------------------------------------------------
+
+function extractAccessType(definition: string): AccessType | undefined {
+  const m = ACCESS_TYPE_RE.exec(definition)
+  if (!m) return undefined
+  switch (m[1].toUpperCase()) {
+    case 'JWT':
+      return AccessType.JWT
+    case 'RECORD':
+      return AccessType.RECORD
+    default:
+      return undefined
+  }
+}
+
+function extractSingleQuoted(re: RegExp, definition: string): string | undefined {
+  const m = re.exec(definition)
+  return m ? m[1] : undefined
+}
+
+/**
+ * Parse a single `DEFINE ACCESS <name> ON DATABASE TYPE {JWT|RECORD} ...`
+ * statement into an `AccessDefinition`. Returns `undefined` when the access
+ * type cannot be determined.
+ */
+export function parseAccess(name: string, definition: string): AccessDefinition | undefined {
+  if (!definition || definition.trim().length === 0) return undefined
+  const type = extractAccessType(definition)
+  if (type === undefined) return undefined
+
+  const acc: Mutable<AccessDefinition> = { name, type }
+
+  if (type === AccessType.JWT) {
+    const algorithm = extractSingleQuoted(ALGORITHM_RE, definition) ?? 'HS256'
+    const jwt: Mutable<JwtConfig> = { algorithm }
+    const key = extractSingleQuoted(KEY_RE, definition)
+    if (key !== undefined) jwt.key = key
+    const url = extractSingleQuoted(URL_RE, definition)
+    if (url !== undefined) jwt.url = url
+    const issuer = extractSingleQuoted(ISSUER_RE, definition)
+    if (issuer !== undefined) jwt.issuer = issuer
+    acc.jwt = Object.freeze(jwt)
+  } else if (type === AccessType.RECORD) {
+    const rec: Mutable<RecordAccessConfig> = {}
+    const signup = SIGNUP_RE.exec(definition)
+    if (signup) rec.signup = signup[1].trim()
+    const signin = SIGNIN_RE.exec(definition)
+    if (signin) rec.signin = signin[1].trim()
+    acc.record = Object.freeze(rec)
+  }
+
+  const session = SESSION_RE.exec(definition)
+  if (session) acc.durationSession = session[1]
+  const token = TOKEN_RE.exec(definition)
+  if (token) acc.durationToken = token[1]
+
+  return Object.freeze(acc)
+}
+
+// ---------------------------------------------------------------------------
+// Table / DB glue
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the `DEFINE TABLE` statement string into a `TableMode`.
+ *
+ * An empty input defaults to `TableMode.SCHEMALESS`, mirroring py/rs/go.
+ */
+export function parseTableMode(definition: string): TableMode {
+  if (!definition) return TableMode.SCHEMALESS
+  const upper = definition.toUpperCase()
+  if (upper.includes('SCHEMAFULL')) return TableMode.SCHEMAFULL
+  if (upper.includes('SCHEMALESS')) return TableMode.SCHEMALESS
+  if (upper.includes('DROP')) return TableMode.DROP
+  return TableMode.SCHEMALESS
+}
+
+/**
+ * Parse a SurrealDB `INFO FOR TABLE` response into a `TableDefinition`.
+ *
+ * Accepts either short-key (`fd`, `ix`, `ev`) or long-key (`fields`,
+ * `indexes`, `events`) shapes. When both are present the long-key map wins,
+ * matching py/rs behaviour.
+ *
+ * @param tableName - name of the table (attached to the returned definition)
+ * @param info - the raw `INFO FOR TABLE` response object
+ * @throws {@link SchemaParseError} when `info` is not a plain object
+ */
+export function parseTableInfo(tableName: string, info: unknown): TableDefinition {
+  if (!tableName || tableName.trim().length === 0) {
+    throw new SchemaParseError('parseTableInfo: table name is required')
+  }
+  const obj = expectObject(info, `INFO FOR TABLE ${tableName}`)
+
+  const mode = parseTableMode(stringAt(obj, 'tb'))
+
+  const fieldsValue = pickMap(obj, ['fields', 'fd'])
+  const fields = fieldsValue ? parseFields(valueToStringMap(fieldsValue)) : []
+
+  const indexesValue = pickMap(obj, ['indexes', 'ix'])
+  const indexes = indexesValue ? parseIndexes(valueToStringMap(indexesValue)) : []
+
+  const eventsValue = pickMap(obj, ['events', 'ev'])
+  const events = eventsValue ? parseEvents(valueToStringMap(eventsValue)) : []
+
+  return Object.freeze({
+    name: tableName,
+    mode,
+    fields,
+    indexes,
+    events,
+  })
+}
+
+function isEdgeDefinition(source: string): boolean {
+  return RELATION_RE.test(source)
+}
+
+function extractRelationEndpoints(definition: string): { from: string; to: string } | undefined {
+  const m = RELATION_RE.exec(definition)
+  if (!m) return undefined
+  return { from: m[1], to: m[2] }
+}
+
+/**
+ * Parse a SurrealDB `INFO FOR TABLE` response that represents a relation edge
+ * into an `EdgeDefinition`.
+ *
+ * @throws {@link SchemaParseError} when `info` is not a plain object or the
+ *   underlying `tb` statement is not a `TYPE RELATION ...` declaration.
+ */
+export function parseEdgeInfo(edgeName: string, info: unknown): EdgeDefinition {
+  if (!edgeName || edgeName.trim().length === 0) {
+    throw new SchemaParseError('parseEdgeInfo: edge name is required')
+  }
+  const obj = expectObject(info, `INFO FOR TABLE ${edgeName}`)
+
+  const tb = stringAt(obj, 'tb')
+  const endpoints = extractRelationEndpoints(tb)
+
+  const fieldsValue = pickMap(obj, ['fields', 'fd'])
+  const fields = fieldsValue ? parseFields(valueToStringMap(fieldsValue)) : []
+  const indexesValue = pickMap(obj, ['indexes', 'ix'])
+  const indexes = indexesValue ? parseIndexes(valueToStringMap(indexesValue)) : []
+  const eventsValue = pickMap(obj, ['events', 'ev'])
+  const events = eventsValue ? parseEvents(valueToStringMap(eventsValue)) : []
+
+  const edge: Mutable<EdgeDefinition> = {
+    name: edgeName,
+    mode: EdgeMode.RELATION,
+    fields,
+    indexes,
+    events,
+  }
+  if (endpoints) {
+    edge.fromTable = endpoints.from
+    edge.toTable = endpoints.to
+  }
+
+  return Object.freeze(edge)
+}
+
+/**
+ * Parse a SurrealDB `INFO FOR DB` response into a `DatabaseInfo`.
+ *
+ * Tables declared with `TYPE RELATION FROM ... TO ...` are routed into
+ * `edges`; every other table becomes a `TableDefinition` in `tables`.
+ * Database-level access definitions land in `accesses`.
+ *
+ * @throws {@link SchemaParseError} when `info` is not a plain object
+ */
+export function parseDbInfo(info: unknown): DatabaseInfo {
+  const obj = expectObject(info, 'INFO FOR DB')
+
+  const tables: Record<string, TableDefinition> = {}
+  const edges: Record<string, EdgeDefinition> = {}
+  const accesses: Record<string, AccessDefinition> = {}
+
+  const tb = pickMap(obj, ['tables', 'tb'])
+  if (tb) {
+    for (const [name, rawDef] of Object.entries(tb)) {
+      if (typeof rawDef !== 'string') continue
+      if (isEdgeDefinition(rawDef)) {
+        const endpoints = extractRelationEndpoints(rawDef)
+        const edge: Mutable<EdgeDefinition> = {
+          name,
+          mode: EdgeMode.RELATION,
+          fields: [],
+          indexes: [],
+          events: [],
+        }
+        if (endpoints) {
+          edge.fromTable = endpoints.from
+          edge.toTable = endpoints.to
+        }
+        edges[name] = Object.freeze(edge)
+      } else {
+        const mode = parseTableMode(rawDef)
+        const table: TableDefinition = {
+          name,
+          mode,
+          fields: [],
+          indexes: [],
+          events: [],
+        }
+        tables[name] = Object.freeze(table)
+      }
+    }
+  }
+
+  const ac = pickMap(obj, ['accesses', 'ac'])
+  if (ac) {
+    for (const [name, rawDef] of Object.entries(ac)) {
+      if (typeof rawDef !== 'string') continue
+      const parsed = parseAccess(name, rawDef)
+      if (parsed !== undefined) accesses[name] = parsed
+    }
+  }
+
+  return Object.freeze({
+    tables: Object.freeze(tables),
+    edges: Object.freeze(edges),
+    accesses: Object.freeze(accesses),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Live-database helpers (convenience)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch an `INFO FOR TABLE <name>` response from a live database and parse it
+ * into a `TableDefinition`.
+ */
+export async function fetchTableInfo(db: Surreal, tableName: string): Promise<TableDefinition> {
   try {
     const results = await db.query<Record<string, unknown>[]>(`INFO FOR TABLE ${tableName}`)
-    const raw = (results as unknown[])[0] as Record<string, unknown>
-    const info = parseTableInfo(raw)
-    return { ...info, name: tableName }
+    const raw = (results as unknown[])[0]
+    return parseTableInfo(tableName, raw)
   } catch (e) {
     throw intoSurQlError(`Failed to fetch info for table ${tableName}:`, e)
   }
 }
 
 /**
- * Fetch and parse database info
+ * Fetch an `INFO FOR DB` response from a live database and parse it into a
+ * `DatabaseInfo`.
  */
-export async function fetchDbInfo(db: Surreal): Promise<ParsedDbInfo> {
+export async function fetchDbInfo(db: Surreal): Promise<DatabaseInfo> {
   try {
     const results = await db.query<Record<string, unknown>[]>('INFO FOR DB')
-    const raw = (results as unknown[])[0] as Record<string, unknown>
+    const raw = (results as unknown[])[0]
     return parseDbInfo(raw)
   } catch (e) {
     throw intoSurQlError('Failed to fetch database info:', e)

--- a/src/schema/sql.ts
+++ b/src/schema/sql.ts
@@ -69,6 +69,13 @@ function generateIndexSql(tableName: string, idx: IndexDefinition): string {
       if (idx.mtreeVectorType) sql += ` TYPE ${idx.mtreeVectorType}`
       if (idx.mtreeCapacity) sql += ` CAPACITY ${idx.mtreeCapacity}`
       break
+    case IndexType.HNSW:
+      sql += ` HNSW DIMENSION ${idx.mtreeDimension}`
+      if (idx.hnswDistance) sql += ` DIST ${idx.hnswDistance}`
+      if (idx.mtreeVectorType) sql += ` TYPE ${idx.mtreeVectorType}`
+      if (idx.hnswEfc !== undefined) sql += ` EFC ${idx.hnswEfc}`
+      if (idx.hnswM !== undefined) sql += ` M ${idx.hnswM}`
+      break
   }
 
   return sql + ';'

--- a/src/schema/table.ts
+++ b/src/schema/table.ts
@@ -17,6 +17,7 @@ export enum IndexType {
   UNIQUE = 'UNIQUE',
   SEARCH = 'SEARCH',
   MTREE = 'MTREE',
+  HNSW = 'HNSW',
 }
 
 /**
@@ -30,7 +31,21 @@ export enum MTreeDistanceType {
 }
 
 /**
- * MTREE vector type
+ * HNSW vector distance metric
+ */
+export enum HnswDistanceType {
+  CHEBYSHEV = 'CHEBYSHEV',
+  COSINE = 'COSINE',
+  EUCLIDEAN = 'EUCLIDEAN',
+  HAMMING = 'HAMMING',
+  JACCARD = 'JACCARD',
+  MANHATTAN = 'MANHATTAN',
+  MINKOWSKI = 'MINKOWSKI',
+  PEARSON = 'PEARSON',
+}
+
+/**
+ * MTREE vector type (also used for HNSW)
  */
 export enum MTreeVectorType {
   F64 = 'F64',
@@ -52,6 +67,9 @@ export interface IndexDefinition {
   readonly mtreeDimension?: number
   readonly mtreeVectorType?: MTreeVectorType
   readonly mtreeCapacity?: number
+  readonly hnswDistance?: HnswDistanceType
+  readonly hnswEfc?: number
+  readonly hnswM?: number
 }
 
 /**
@@ -161,6 +179,30 @@ export function mtreeIndex(
     mtreeDistance: options.distance ?? MTreeDistanceType.COSINE,
     mtreeVectorType: options.vectorType ?? MTreeVectorType.F64,
     mtreeCapacity: options.capacity,
+  })
+}
+
+/** Create an HNSW vector index */
+export function hnswIndex(
+  name: string,
+  field: string,
+  dimension: number,
+  options: {
+    distance?: HnswDistanceType
+    vectorType?: MTreeVectorType
+    efc?: number
+    m?: number
+  } = {},
+): IndexDefinition {
+  return Object.freeze({
+    name,
+    fields: [field],
+    type: IndexType.HNSW,
+    mtreeDimension: dimension,
+    mtreeVectorType: options.vectorType ?? MTreeVectorType.F32,
+    hnswDistance: options.distance ?? HnswDistanceType.COSINE,
+    hnswEfc: options.efc,
+    hnswM: options.m,
   })
 }
 

--- a/src/test/integration_crud.test.ts
+++ b/src/test/integration_crud.test.ts
@@ -473,7 +473,6 @@ describe('Integration: schema parser', () => {
   it('fetchDbInfo should return database info with tables key', async () => {
     await db.query('DEFINE TABLE parser_table SCHEMALESS')
     const info = await fetchDbInfo(db)
-    assertEquals(typeof info.tables, 'object')
     assert('parser_table' in info.tables)
   })
 
@@ -485,16 +484,14 @@ describe('Integration: schema parser', () => {
     `)
     const info = await fetchTableInfo(db, 'parser_table')
     assertEquals(info.name, 'parser_table')
-    assertEquals(typeof info.fields, 'object')
-    assertEquals(typeof info.indexes, 'object')
-    assert('name' in info.fields)
-    assert('idx_name' in info.indexes)
+    assert(info.fields.some((f) => f.name === 'name'))
+    assert(info.indexes.some((i) => i.name === 'idx_name'))
   })
 
   it('fetchTableInfo should return empty collections for schemaless table', async () => {
     await db.query('DEFINE TABLE parser_table SCHEMALESS')
     const info = await fetchTableInfo(db, 'parser_table')
-    assertEquals(Object.keys(info.fields).length, 0)
+    assertEquals(info.fields.length, 0)
   })
 })
 

--- a/src/test/schema_parser.test.ts
+++ b/src/test/schema_parser.test.ts
@@ -1,97 +1,616 @@
-import { assertEquals, assertRejects } from '@std/assert'
+import { assert, assertEquals, assertRejects, assertThrows } from '@std/assert'
 import { describe, it } from '@std/testing/bdd'
-import { fetchDbInfo, fetchTableInfo, parseDbInfo, parseTableInfo } from '../schema/parser.ts'
+import {
+  fetchDbInfo,
+  fetchTableInfo,
+  parseAccess,
+  parseDbInfo,
+  parseEdgeInfo,
+  parseEvent,
+  parseEvents,
+  parseField,
+  parseFields,
+  parseIndex,
+  parseIndexes,
+  parseTableInfo,
+  parseTableMode,
+  SchemaParseError,
+} from '../schema/parser.ts'
+import { AccessType } from '../schema/access.ts'
+import { EdgeMode } from '../schema/edge.ts'
+import { FieldType } from '../schema/fields.ts'
+import {
+  HnswDistanceType,
+  hnswIndex,
+  IndexType,
+  MTreeDistanceType,
+  mtreeIndex,
+  MTreeVectorType,
+  searchIndex,
+  TableMode,
+  tableSchema,
+  uniqueIndex,
+  withFields,
+  withIndexes,
+} from '../schema/table.ts'
+import { datetimeField, intField, stringField } from '../schema/fields.ts'
+import { generateTableSql } from '../schema/sql.ts'
+
+// ---------------------------------------------------------------------------
+// parseTableMode
+// ---------------------------------------------------------------------------
+
+describe('parseTableMode', () => {
+  it('returns SCHEMALESS for empty input', () => {
+    assertEquals(parseTableMode(''), TableMode.SCHEMALESS)
+  })
+
+  it('detects SCHEMAFULL', () => {
+    assertEquals(parseTableMode('DEFINE TABLE user SCHEMAFULL'), TableMode.SCHEMAFULL)
+  })
+
+  it('detects SCHEMALESS', () => {
+    assertEquals(parseTableMode('DEFINE TABLE user SCHEMALESS'), TableMode.SCHEMALESS)
+  })
+
+  it('detects DROP', () => {
+    assertEquals(parseTableMode('DEFINE TABLE tmp DROP'), TableMode.DROP)
+  })
+
+  it('is case insensitive', () => {
+    assertEquals(parseTableMode('define table user schemafull'), TableMode.SCHEMAFULL)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseField
+// ---------------------------------------------------------------------------
+
+describe('parseField', () => {
+  it('returns undefined for empty definition', () => {
+    assertEquals(parseField('x', ''), undefined)
+    assertEquals(parseField('x', '   '), undefined)
+  })
+
+  it('parses basic string field', () => {
+    const f = parseField('email', 'DEFINE FIELD email ON TABLE user TYPE string')!
+    assertEquals(f.name, 'email')
+    assertEquals(f.type, FieldType.STRING)
+    assertEquals(f.assertion, undefined)
+    assertEquals(f.readonly, undefined)
+  })
+
+  it('maps every known type keyword', () => {
+    const cases: Array<[string, FieldType]> = [
+      ['string', FieldType.STRING],
+      ['int', FieldType.INT],
+      ['float', FieldType.FLOAT],
+      ['bool', FieldType.BOOL],
+      ['datetime', FieldType.DATETIME],
+      ['duration', FieldType.DURATION],
+      ['decimal', FieldType.DECIMAL],
+      ['number', FieldType.NUMBER],
+      ['object', FieldType.OBJECT],
+      ['array', FieldType.ARRAY],
+      ['record', FieldType.RECORD],
+      ['geometry', FieldType.GEOMETRY],
+      ['any', FieldType.ANY],
+    ]
+    for (const [kw, want] of cases) {
+      const f = parseField('x', `DEFINE FIELD x ON TABLE u TYPE ${kw}`)!
+      assertEquals(f.type, want, `type ${kw} should map to ${want}`)
+    }
+  })
+
+  it('falls back to ANY on unknown type', () => {
+    const f = parseField('x', 'DEFINE FIELD x ON TABLE t TYPE unknown_type_value')!
+    assertEquals(f.type, FieldType.ANY)
+  })
+
+  it('falls back to ANY when TYPE clause is missing', () => {
+    const f = parseField('x', 'DEFINE FIELD x ON TABLE t')!
+    assertEquals(f.type, FieldType.ANY)
+  })
+
+  it('extracts ASSERT and DEFAULT', () => {
+    const f = parseField('age', 'DEFINE FIELD age ON TABLE user TYPE int ASSERT $value >= 0 DEFAULT 0')!
+    assertEquals(f.type, FieldType.INT)
+    assertEquals(f.assertion, '$value >= 0')
+    assertEquals(f.defaultValue, '0')
+  })
+
+  it('extracts VALUE, READONLY, FLEXIBLE simultaneously', () => {
+    const f = parseField(
+      'full',
+      'DEFINE FIELD full ON TABLE user TYPE string VALUE string::concat(a,b) READONLY FLEXIBLE',
+    )!
+    assertEquals(f.value, 'string::concat(a,b)')
+    assertEquals(f.readonly, true)
+    assertEquals(f.flexible, true)
+  })
+
+  it('$value lookbehind: VALUE clause does not swallow $value in ASSERT', () => {
+    // Regression: a naive `VALUE\s+` match would capture the `value` in
+    // `$value`. The word-boundary aware extractor must not.
+    const f = parseField(
+      'score',
+      'DEFINE FIELD score ON TABLE user TYPE int ASSERT $value >= 0 AND $value <= 100',
+    )!
+    assertEquals(f.type, FieldType.INT)
+    assertEquals(f.assertion, '$value >= 0 AND $value <= 100')
+    assertEquals(f.value, undefined)
+  })
+
+  it('$before/$after lookbehind: keywords inside identifiers are ignored', () => {
+    const f = parseField(
+      'guard',
+      'DEFINE FIELD guard ON TABLE user TYPE int ASSERT $before.count != $after.count',
+    )!
+    assertEquals(f.assertion, '$before.count != $after.count')
+    assertEquals(f.defaultValue, undefined)
+    assertEquals(f.value, undefined)
+  })
+
+  it('handles lowercase READONLY', () => {
+    const f = parseField('x', 'DEFINE FIELD x ON TABLE t TYPE string readonly')!
+    assertEquals(f.readonly, true)
+  })
+
+  it('round-trips through generateFieldSql-like shape', () => {
+    const def = "DEFINE FIELD email ON TABLE user TYPE string ASSERT $value != NONE DEFAULT 'a@b.com'"
+    const f = parseField('email', def)!
+    assertEquals(f.assertion, '$value != NONE')
+    assertEquals(f.defaultValue, "'a@b.com'")
+  })
+})
+
+describe('parseFields', () => {
+  it('parses every entry of a name→definition map', () => {
+    const out = parseFields({
+      email: 'DEFINE FIELD email ON TABLE user TYPE string',
+      age: 'DEFINE FIELD age ON TABLE user TYPE int',
+    })
+    assertEquals(out.length, 2)
+    assertEquals(out.find((f) => f.name === 'age')?.type, FieldType.INT)
+  })
+
+  it('skips empty definition entries', () => {
+    const out = parseFields({ good: 'DEFINE FIELD good ON TABLE t TYPE string', empty: '' })
+    assertEquals(out.length, 1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseIndex
+// ---------------------------------------------------------------------------
+
+describe('parseIndex', () => {
+  it('returns undefined for empty definition', () => {
+    assertEquals(parseIndex('ix', ''), undefined)
+    assertEquals(parseIndex('ix', '   '), undefined)
+  })
+
+  it('parses standard COLUMNS index', () => {
+    const i = parseIndex('title_idx', 'DEFINE INDEX title_idx ON TABLE post COLUMNS title')!
+    assertEquals(i.type, IndexType.STANDARD)
+    assertEquals(i.fields, ['title'])
+  })
+
+  it('parses UNIQUE using FIELDS alias', () => {
+    const i = parseIndex('email_idx', 'DEFINE INDEX email_idx ON TABLE user FIELDS email UNIQUE')!
+    assertEquals(i.type, IndexType.UNIQUE)
+    assertEquals(i.fields, ['email'])
+  })
+
+  it('parses multi-column index', () => {
+    const i = parseIndex('composite', 'DEFINE INDEX composite ON TABLE user COLUMNS a, b, c UNIQUE')!
+    assertEquals(i.fields, ['a', 'b', 'c'])
+  })
+
+  it('parses SEARCH index', () => {
+    const i = parseIndex(
+      'content_search',
+      'DEFINE INDEX content_search ON TABLE post COLUMNS title, content SEARCH ANALYZER ascii',
+    )!
+    assertEquals(i.type, IndexType.SEARCH)
+    assertEquals(i.fields.length, 2)
+  })
+
+  it('parses MTREE with dimension, distance, vector type', () => {
+    const i = parseIndex(
+      'emb_idx',
+      'DEFINE INDEX emb_idx ON TABLE doc COLUMNS embedding MTREE DIMENSION 1536 DIST COSINE TYPE F32',
+    )!
+    assertEquals(i.type, IndexType.MTREE)
+    assertEquals(i.mtreeDimension, 1536)
+    assertEquals(i.mtreeDistance, MTreeDistanceType.COSINE)
+    assertEquals(i.mtreeVectorType, MTreeVectorType.F32)
+  })
+
+  it('parses HNSW with EFC and M', () => {
+    const i = parseIndex(
+      'feat_idx',
+      'DEFINE INDEX feat_idx ON TABLE doc COLUMNS features HNSW DIMENSION 128 DIST COSINE TYPE F32 EFC 500 M 16',
+    )!
+    assertEquals(i.type, IndexType.HNSW)
+    assertEquals(i.mtreeDimension, 128)
+    assertEquals(i.hnswDistance, HnswDistanceType.COSINE)
+    assertEquals(i.mtreeVectorType, MTreeVectorType.F32)
+    assertEquals(i.hnswEfc, 500)
+    assertEquals(i.hnswM, 16)
+  })
+
+  it('parses HNSW without EFC/M', () => {
+    const i = parseIndex(
+      'feat_idx',
+      'DEFINE INDEX feat_idx ON TABLE doc COLUMNS features HNSW DIMENSION 64 DIST EUCLIDEAN TYPE F64',
+    )!
+    assertEquals(i.type, IndexType.HNSW)
+    assertEquals(i.hnswEfc, undefined)
+    assertEquals(i.hnswM, undefined)
+    assertEquals(i.hnswDistance, HnswDistanceType.EUCLIDEAN)
+    assertEquals(i.mtreeVectorType, MTreeVectorType.F64)
+  })
+
+  it('supports HNSW Chebyshev distance', () => {
+    const i = parseIndex('h', 'DEFINE INDEX h ON TABLE x COLUMNS v HNSW DIMENSION 4 DIST CHEBYSHEV')!
+    assertEquals(i.hnswDistance, HnswDistanceType.CHEBYSHEV)
+  })
+
+  it('returns empty columns when COLUMNS/FIELDS clause absent', () => {
+    const i = parseIndex('x', 'DEFINE INDEX x ON TABLE t')!
+    assertEquals(i.fields, [])
+    assertEquals(i.type, IndexType.STANDARD)
+  })
+})
+
+describe('parseIndexes', () => {
+  it('parses many', () => {
+    const out = parseIndexes({
+      a: 'DEFINE INDEX a ON TABLE t COLUMNS a',
+      b: 'DEFINE INDEX b ON TABLE t COLUMNS b UNIQUE',
+    })
+    assertEquals(out.length, 2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseEvent
+// ---------------------------------------------------------------------------
+
+describe('parseEvent', () => {
+  it('returns undefined for empty definition', () => {
+    assertEquals(parseEvent('e', ''), undefined)
+  })
+
+  it('parses bare THEN action', () => {
+    const e = parseEvent(
+      'email_changed',
+      'DEFINE EVENT email_changed ON TABLE user WHEN $before.email != $after.email THEN CREATE audit_log;',
+    )!
+    assertEquals(e.when, '$before.email != $after.email')
+    assertEquals(e.then, 'CREATE audit_log')
+  })
+
+  it('parses brace-wrapped THEN action', () => {
+    const e = parseEvent(
+      'n',
+      'DEFINE EVENT n ON TABLE t WHEN true THEN { CREATE audit_log };',
+    )!
+    assertEquals(e.then, 'CREATE audit_log')
+  })
+
+  it('returns undefined when THEN clause is missing', () => {
+    assertEquals(parseEvent('n', 'DEFINE EVENT n ON TABLE t WHEN true;'), undefined)
+  })
+})
+
+describe('parseEvents', () => {
+  it('parses many', () => {
+    const out = parseEvents({
+      a: 'DEFINE EVENT a ON TABLE t WHEN true THEN CREATE log;',
+      b: 'DEFINE EVENT b ON TABLE t WHEN false THEN { DELETE log };',
+    })
+    assertEquals(out.length, 2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseAccess
+// ---------------------------------------------------------------------------
+
+describe('parseAccess', () => {
+  it('returns undefined for empty or unknown type', () => {
+    assertEquals(parseAccess('x', ''), undefined)
+    assertEquals(parseAccess('x', 'DEFINE ACCESS x ON DATABASE TYPE BOGUS;'), undefined)
+  })
+
+  it('parses JWT HS256 with key', () => {
+    const a = parseAccess(
+      'api',
+      "DEFINE ACCESS api ON DATABASE TYPE JWT ALGORITHM HS256 KEY 'secret';",
+    )!
+    assertEquals(a.type, AccessType.JWT)
+    assertEquals(a.jwt?.algorithm, 'HS256')
+    assertEquals(a.jwt?.key, 'secret')
+  })
+
+  it('parses JWT with URL and issuer', () => {
+    const a = parseAccess(
+      'api',
+      "DEFINE ACCESS api ON DATABASE TYPE JWT ALGORITHM RS256 URL 'https://auth.example.com/jwks' WITH ISSUER 'https://auth.example.com';",
+    )!
+    assertEquals(a.jwt?.algorithm, 'RS256')
+    assertEquals(a.jwt?.url, 'https://auth.example.com/jwks')
+    assertEquals(a.jwt?.issuer, 'https://auth.example.com')
+  })
+
+  it('parses RECORD signup/signin + durations', () => {
+    const a = parseAccess(
+      'user_auth',
+      'DEFINE ACCESS user_auth ON DATABASE TYPE RECORD SIGNUP (CREATE user) SIGNIN (SELECT * FROM user) DURATION FOR SESSION 24h, FOR TOKEN 15m;',
+    )!
+    assertEquals(a.type, AccessType.RECORD)
+    assertEquals(a.record?.signup, 'CREATE user')
+    assertEquals(a.record?.signin, 'SELECT * FROM user')
+    assertEquals(a.durationSession, '24h')
+    assertEquals(a.durationToken, '15m')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseTableInfo
+// ---------------------------------------------------------------------------
 
 describe('parseTableInfo', () => {
-  it('should parse standard field names', () => {
-    const raw = {
-      fields: { name: 'DEFINE FIELD name ON users TYPE string' },
-      indexes: { idx_name: 'DEFINE INDEX idx_name ON users FIELDS name' },
-      events: { on_create: 'DEFINE EVENT on_create ON users ...' },
-      lives: {},
+  it('rejects non-object input with SchemaParseError', () => {
+    assertThrows(() => parseTableInfo('user', null), SchemaParseError)
+    assertThrows(() => parseTableInfo('user', 'not an object'), SchemaParseError)
+    assertThrows(() => parseTableInfo('user', [1, 2, 3]), SchemaParseError)
+  })
+
+  it('rejects empty table name', () => {
+    assertThrows(() => parseTableInfo('', {}), SchemaParseError)
+  })
+
+  it('parses short-key payload', () => {
+    const info = {
+      tb: 'DEFINE TABLE user SCHEMAFULL',
+      fd: { email: 'DEFINE FIELD email ON TABLE user TYPE string' },
+      ix: { e_idx: 'DEFINE INDEX e_idx ON TABLE user COLUMNS email UNIQUE' },
+      ev: { on_change: 'DEFINE EVENT on_change ON TABLE user WHEN true THEN CREATE log;' },
     }
-    const result = parseTableInfo(raw)
-    assertEquals(result.fields.name, 'DEFINE FIELD name ON users TYPE string')
-    assertEquals(result.indexes.idx_name, 'DEFINE INDEX idx_name ON users FIELDS name')
-    assertEquals(result.events.on_create, 'DEFINE EVENT on_create ON users ...')
-    assertEquals(Object.keys(result.lives).length, 0)
+    const t = parseTableInfo('user', info)
+    assertEquals(t.name, 'user')
+    assertEquals(t.mode, TableMode.SCHEMAFULL)
+    assertEquals(t.fields.length, 1)
+    assertEquals(t.indexes.length, 1)
+    assertEquals(t.events.length, 1)
   })
 
-  it('should parse abbreviated field names (fd, ix, ev, lv)', () => {
-    const raw = {
-      fd: { email: 'DEFINE FIELD email ...' },
-      ix: { idx_email: 'DEFINE INDEX idx_email ...' },
-      ev: {},
-      lv: { live1: 'LIVE SELECT ...' },
+  it('parses long-key payload', () => {
+    const info = {
+      tb: 'DEFINE TABLE post SCHEMALESS',
+      fields: { title: 'DEFINE FIELD title ON TABLE post TYPE string' },
+      indexes: {},
+      events: {},
     }
-    const result = parseTableInfo(raw)
-    assertEquals(result.fields.email, 'DEFINE FIELD email ...')
-    assertEquals(result.indexes.idx_email, 'DEFINE INDEX idx_email ...')
-    assertEquals(result.lives.live1, 'LIVE SELECT ...')
+    const t = parseTableInfo('post', info)
+    assertEquals(t.mode, TableMode.SCHEMALESS)
+    assertEquals(t.fields.length, 1)
   })
 
-  it('should default to empty objects for missing keys', () => {
-    const result = parseTableInfo({})
-    assertEquals(Object.keys(result.fields).length, 0)
-    assertEquals(Object.keys(result.indexes).length, 0)
-    assertEquals(Object.keys(result.events).length, 0)
-    assertEquals(Object.keys(result.lives).length, 0)
-  })
-
-  it('should set name to empty string', () => {
-    const result = parseTableInfo({})
-    assertEquals(result.name, '')
-  })
-
-  it('should prefer standard names over abbreviated', () => {
-    const raw = {
-      fields: { name: 'standard' },
-      fd: { name: 'abbreviated' },
+  it('prefers long-key map when both are present', () => {
+    const info = {
+      tb: 'DEFINE TABLE user SCHEMAFULL',
+      fields: { a: 'DEFINE FIELD a ON TABLE user TYPE string' },
+      fd: { b: 'DEFINE FIELD b ON TABLE user TYPE int' },
     }
-    const result = parseTableInfo(raw)
-    assertEquals(result.fields.name, 'standard')
+    const t = parseTableInfo('user', info)
+    assertEquals(t.fields.length, 1)
+    assertEquals(t.fields[0].name, 'a')
+  })
+
+  it('defaults to SCHEMALESS when tb is missing', () => {
+    const t = parseTableInfo('post', {})
+    assertEquals(t.mode, TableMode.SCHEMALESS)
+    assertEquals(t.fields.length, 0)
   })
 })
+
+// ---------------------------------------------------------------------------
+// parseDbInfo
+// ---------------------------------------------------------------------------
 
 describe('parseDbInfo', () => {
-  it('should parse standard field names', () => {
-    const raw = {
-      tables: { users: 'DEFINE TABLE users ...' },
-      accesses: { jwt: 'DEFINE ACCESS jwt ...' },
-      analyzers: {},
-      functions: { fn_test: 'DEFINE FUNCTION fn_test ...' },
-      params: {},
-    }
-    const result = parseDbInfo(raw)
-    assertEquals(result.tables.users, 'DEFINE TABLE users ...')
-    assertEquals(result.accesses.jwt, 'DEFINE ACCESS jwt ...')
-    assertEquals(result.functions.fn_test, 'DEFINE FUNCTION fn_test ...')
+  it('rejects non-object input with SchemaParseError', () => {
+    assertThrows(() => parseDbInfo([1, 2, 3]), SchemaParseError)
+    assertThrows(() => parseDbInfo(null), SchemaParseError)
   })
 
-  it('should parse abbreviated field names (tb, ac, az, fn, pa)', () => {
-    const raw = {
-      tb: { posts: 'DEFINE TABLE posts ...' },
-      ac: { record_access: 'DEFINE ACCESS ...' },
-      az: { ascii: 'DEFINE ANALYZER ascii ...' },
-      fn: {},
-      pa: { my_param: '$my_param = 42' },
-    }
-    const result = parseDbInfo(raw)
-    assertEquals(result.tables.posts, 'DEFINE TABLE posts ...')
-    assertEquals(result.accesses.record_access, 'DEFINE ACCESS ...')
-    assertEquals(result.analyzers.ascii, 'DEFINE ANALYZER ascii ...')
-    assertEquals(result.params.my_param, '$my_param = 42')
+  it('returns empty maps for empty object', () => {
+    const db = parseDbInfo({})
+    assertEquals(Object.keys(db.tables).length, 0)
+    assertEquals(Object.keys(db.edges).length, 0)
+    assertEquals(Object.keys(db.accesses).length, 0)
   })
 
-  it('should default to empty objects for missing keys', () => {
-    const result = parseDbInfo({})
-    assertEquals(Object.keys(result.tables).length, 0)
-    assertEquals(Object.keys(result.accesses).length, 0)
-    assertEquals(Object.keys(result.analyzers).length, 0)
-    assertEquals(Object.keys(result.functions).length, 0)
-    assertEquals(Object.keys(result.params).length, 0)
+  it('partitions RELATION tables into edges', () => {
+    const info = {
+      tb: {
+        user: 'DEFINE TABLE user SCHEMAFULL',
+        post: 'DEFINE TABLE post SCHEMALESS',
+        likes: 'DEFINE TABLE likes TYPE RELATION FROM user TO post',
+      },
+    }
+    const db = parseDbInfo(info)
+    assertEquals(Object.keys(db.tables).length, 2)
+    assertEquals(Object.keys(db.edges).length, 1)
+    const edge = db.edges.likes
+    assertEquals(edge.mode, EdgeMode.RELATION)
+    assertEquals(edge.fromTable, 'user')
+    assertEquals(edge.toTable, 'post')
+  })
+
+  it('accepts long-key tables/accesses', () => {
+    const info = {
+      tables: { user: 'DEFINE TABLE user SCHEMAFULL' },
+      accesses: {
+        api: "DEFINE ACCESS api ON DATABASE TYPE JWT ALGORITHM HS256 KEY 'secret';",
+      },
+    }
+    const db = parseDbInfo(info)
+    assertEquals(Object.keys(db.tables).length, 1)
+    assertEquals(Object.keys(db.accesses).length, 1)
+    assertEquals(db.accesses.api.type, AccessType.JWT)
+  })
+
+  it('ignores non-string table entries', () => {
+    const info = {
+      tb: {
+        user: 'DEFINE TABLE user SCHEMAFULL',
+        bogus: 42,
+      },
+    }
+    const db = parseDbInfo(info)
+    assertEquals(Object.keys(db.tables).length, 1)
+    assert('user' in db.tables)
+  })
+
+  it('skips malformed access entries', () => {
+    const info = {
+      ac: {
+        good: "DEFINE ACCESS good ON DATABASE TYPE JWT ALGORITHM HS256 KEY 'k';",
+        bad: 'DEFINE ACCESS bad ON DATABASE TYPE UNKNOWN;',
+      },
+    }
+    const db = parseDbInfo(info)
+    assert('good' in db.accesses)
+    assertEquals(db.accesses.bad, undefined)
   })
 })
+
+// ---------------------------------------------------------------------------
+// parseEdgeInfo
+// ---------------------------------------------------------------------------
+
+describe('parseEdgeInfo', () => {
+  it('rejects empty name', () => {
+    assertThrows(() => parseEdgeInfo('', {}), SchemaParseError)
+  })
+
+  it('extracts from/to + fields from relation', () => {
+    const info = {
+      tb: 'DEFINE TABLE likes TYPE RELATION FROM user TO product',
+      fields: { weight: 'DEFINE FIELD weight ON TABLE likes TYPE float DEFAULT 1.0' },
+    }
+    const e = parseEdgeInfo('likes', info)
+    assertEquals(e.mode, EdgeMode.RELATION)
+    assertEquals(e.fromTable, 'user')
+    assertEquals(e.toTable, 'product')
+    assertEquals(e.fields.length, 1)
+    assertEquals(e.fields[0].name, 'weight')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Idempotency / round-trip
+// ---------------------------------------------------------------------------
+
+describe('round-trip: generate → parse → regenerate', () => {
+  it('preserves schemafull table with fields and unique index', () => {
+    const table = withIndexes(
+      withFields(
+        tableSchema('user', TableMode.SCHEMAFULL),
+        stringField('email'),
+        intField('age', { assertion: '$value >= 0', defaultValue: '0' }),
+        datetimeField('created_at', { defaultValue: 'time::now()', readonly: true }),
+      ),
+      uniqueIndex('email_idx', 'email'),
+    )
+
+    const sql = generateTableSql(table)
+    const lines = sql.split('\n').map((s) => s.replace(/;$/, ''))
+    const info = {
+      tb: lines[0],
+      fd: {
+        email: lines[1],
+        age: lines[2],
+        created_at: lines[3],
+      },
+      ix: { email_idx: lines[4] },
+    }
+
+    const parsed = parseTableInfo('user', info)
+    assertEquals(parsed.mode, TableMode.SCHEMAFULL)
+    assertEquals(parsed.fields.length, 3)
+    assertEquals(parsed.indexes.length, 1)
+    const age = parsed.fields.find((f) => f.name === 'age')!
+    assertEquals(age.type, FieldType.INT)
+    assertEquals(age.assertion, '$value >= 0')
+    assertEquals(age.defaultValue, '0')
+    const created = parsed.fields.find((f) => f.name === 'created_at')!
+    assertEquals(created.defaultValue, 'time::now()')
+    assertEquals(created.readonly, true)
+    const ix = parsed.indexes[0]
+    assertEquals(ix.type, IndexType.UNIQUE)
+    assertEquals(ix.fields, ['email'])
+  })
+
+  it('preserves MTREE index', () => {
+    const table = withIndexes(
+      tableSchema('doc', TableMode.SCHEMAFULL),
+      mtreeIndex('emb_idx', 'embedding', 1536, {
+        distance: MTreeDistanceType.COSINE,
+        vectorType: MTreeVectorType.F32,
+      }),
+    )
+    const [tb, ix] = generateTableSql(table).split('\n').map((s) => s.replace(/;$/, ''))
+    const parsed = parseTableInfo('doc', { tb, ix: { emb_idx: ix } })
+    const parsedIx = parsed.indexes[0]
+    assertEquals(parsedIx.type, IndexType.MTREE)
+    assertEquals(parsedIx.mtreeDimension, 1536)
+    assertEquals(parsedIx.mtreeDistance, MTreeDistanceType.COSINE)
+    assertEquals(parsedIx.mtreeVectorType, MTreeVectorType.F32)
+  })
+
+  it('preserves HNSW index with EFC/M', () => {
+    const table = withIndexes(
+      tableSchema('doc', TableMode.SCHEMAFULL),
+      hnswIndex('feat_idx', 'features', 128, {
+        distance: HnswDistanceType.COSINE,
+        vectorType: MTreeVectorType.F32,
+        efc: 150,
+        m: 12,
+      }),
+    )
+    const [tb, ix] = generateTableSql(table).split('\n').map((s) => s.replace(/;$/, ''))
+    const parsed = parseTableInfo('doc', { tb, ix: { feat_idx: ix } })
+    const parsedIx = parsed.indexes[0]
+    assertEquals(parsedIx.type, IndexType.HNSW)
+    assertEquals(parsedIx.mtreeDimension, 128)
+    assertEquals(parsedIx.hnswDistance, HnswDistanceType.COSINE)
+    assertEquals(parsedIx.mtreeVectorType, MTreeVectorType.F32)
+    assertEquals(parsedIx.hnswEfc, 150)
+    assertEquals(parsedIx.hnswM, 12)
+  })
+
+  it('preserves SEARCH index columns', () => {
+    const table = withIndexes(
+      tableSchema('post', TableMode.SCHEMAFULL),
+      searchIndex('content_search', ['title', 'content'], 'ascii'),
+    )
+    const [tb, ix] = generateTableSql(table).split('\n').map((s) => s.replace(/;$/, ''))
+    const parsed = parseTableInfo('post', { tb, ix: { content_search: ix } })
+    const parsedIx = parsed.indexes[0]
+    assertEquals(parsedIx.type, IndexType.SEARCH)
+    assertEquals(parsedIx.fields.length, 2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Live-db helpers (mocked)
+// ---------------------------------------------------------------------------
 
 function makeMockDb(response: unknown) {
   return {
@@ -106,21 +625,20 @@ function makeFailingMockDb(error: Error) {
 }
 
 describe('fetchTableInfo', () => {
-  it('should fetch and parse table info', async () => {
+  it('fetches and parses table info', async () => {
     const raw = {
-      fields: { name: 'DEFINE FIELD name ...' },
-      indexes: {},
-      events: {},
-      lives: {},
+      tb: 'DEFINE TABLE users SCHEMAFULL',
+      fields: { name: 'DEFINE FIELD name ON TABLE users TYPE string' },
     }
     // deno-lint-ignore no-explicit-any
     const db = makeMockDb(raw) as any
     const result = await fetchTableInfo(db, 'users')
     assertEquals(result.name, 'users')
-    assertEquals(result.fields.name, 'DEFINE FIELD name ...')
+    assertEquals(result.fields.length, 1)
+    assertEquals(result.fields[0].name, 'name')
   })
 
-  it('should throw SurQlError on failure', async () => {
+  it('throws SurQlError on failure', async () => {
     // deno-lint-ignore no-explicit-any
     const db = makeFailingMockDb(new Error('connection lost')) as any
     await assertRejects(
@@ -132,21 +650,15 @@ describe('fetchTableInfo', () => {
 })
 
 describe('fetchDbInfo', () => {
-  it('should fetch and parse database info', async () => {
-    const raw = {
-      tables: { users: 'DEFINE TABLE users' },
-      accesses: {},
-      analyzers: {},
-      functions: {},
-      params: {},
-    }
+  it('fetches and parses database info', async () => {
+    const raw = { tables: { users: 'DEFINE TABLE users SCHEMAFULL' } }
     // deno-lint-ignore no-explicit-any
     const db = makeMockDb(raw) as any
     const result = await fetchDbInfo(db)
-    assertEquals(result.tables.users, 'DEFINE TABLE users')
+    assert('users' in result.tables)
   })
 
-  it('should throw SurQlError on failure', async () => {
+  it('throws SurQlError on failure', async () => {
     // deno-lint-ignore no-explicit-any
     const db = makeFailingMockDb(new Error('db error')) as any
     await assertRejects(

--- a/src/test/schema_visualize.test.ts
+++ b/src/test/schema_visualize.test.ts
@@ -240,36 +240,34 @@ describe('validateSchema', () => {
 
 describe('parseTableInfo', () => {
   it('should parse fields from raw response using "fields" key', () => {
-    const raw = { fields: { name: 'DEFINE FIELD name ON TABLE t TYPE string' }, indexes: {}, events: {}, lives: {} }
-    const info = parseTableInfo(raw)
-    assertEquals(typeof info.fields, 'object')
-    assert('name' in info.fields)
+    const raw = { tb: 'DEFINE TABLE t', fields: { name: 'DEFINE FIELD name ON TABLE t TYPE string' } }
+    const info = parseTableInfo('t', raw)
+    assert(info.fields.some((f) => f.name === 'name'))
   })
 
   it('should parse fields from raw response using "fd" key (SurrealDB v1 compat)', () => {
-    const raw = { fd: { email: 'DEFINE FIELD email ON TABLE t TYPE string' }, ix: {}, ev: {}, lv: {} }
-    const info = parseTableInfo(raw)
-    assert('email' in info.fields)
+    const raw = { tb: 'DEFINE TABLE t', fd: { email: 'DEFINE FIELD email ON TABLE t TYPE string' } }
+    const info = parseTableInfo('t', raw)
+    assert(info.fields.some((f) => f.name === 'email'))
   })
 
-  it('should default to empty objects when keys are missing', () => {
-    const info = parseTableInfo({})
-    assertEquals(typeof info.fields, 'object')
-    assertEquals(Object.keys(info.fields).length, 0)
-    assertEquals(Object.keys(info.indexes).length, 0)
-    assertEquals(Object.keys(info.events).length, 0)
+  it('should default to empty arrays when keys are missing', () => {
+    const info = parseTableInfo('t', {})
+    assertEquals(info.fields.length, 0)
+    assertEquals(info.indexes.length, 0)
+    assertEquals(info.events.length, 0)
   })
 })
 
 describe('parseDbInfo', () => {
   it('should parse tables from raw response using "tables" key', () => {
-    const raw = { tables: { users: 'DEFINE TABLE users' }, accesses: {}, analyzers: {}, functions: {}, params: {} }
+    const raw = { tables: { users: 'DEFINE TABLE users SCHEMAFULL' } }
     const info = parseDbInfo(raw)
     assert('users' in info.tables)
   })
 
   it('should parse tables from raw response using "tb" key (SurrealDB v1 compat)', () => {
-    const raw = { tb: { posts: 'DEFINE TABLE posts' }, ac: {}, az: {}, fn: {}, pa: {} }
+    const raw = { tb: { posts: 'DEFINE TABLE posts SCHEMALESS' } }
     const info = parseDbInfo(raw)
     assert('posts' in info.tables)
   })


### PR DESCRIPTION
## Summary

Ports the full regex-based `DEFINE FIELD / INDEX / EVENT / ACCESS` parser from `surql-py` (705 LOC), `surql-rs` (1415 LOC), and `surql-go` (760 LOC) into `src/schema/parser.ts`. Replaces the 77-LOC short-key aliasing stub which silently dropped field/index/event/access metadata on every INFO round-trip.

This was the single biggest parity gap in the TS port — drift detection and any schema-diff feature that round-trips `INFO FOR DB` through the parser is finally functional.

## Commits

1. `feat(schema): extend definitions for HNSW index + JWT URL + access durations` — additive type extensions (HNSW + `HnswDistanceType` + `hnswIndex` ctor, `JwtConfig.url`, `AccessDefinition.durationSession/durationToken`, HNSW branch in `generateIndexSql`). Prerequisites for the parser's richer output types.
2. `feat(schema): port structured DEFINE parser from py/rs/go` — parser itself (+747 LOC / −46 LOC).
3. `test(schema): cover structured parser with round-trip + lookbehind cases` — regression suite + migration of legacy stub tests (+511 LOC).

## Surface (new public exports)

`parseField`, `parseIndex`, `parseEvent`, `parseAccess`, `parseFields`, `parseIndexes`, `parseTableMode`, `parseTableInfo` (replaces stub), `parseDbInfo` (replaces stub), `SchemaParseError`.

## Deliberate deviations from references

- `TableDefinition.drop` flag kept at parity with py/go (rs has it; py + go don't; TS follows the majority).
- `FieldDefinition.permissions` FOR-clause parsing: deferred in every reference port — same here.
- One upward deviation from rs: `require_whitespace_left=true` at the anchor regex (matches go's correct behaviour; rs has a latent edge case).

## Test plan

- [x] \`deno task fmt --check\` clean
- [x] \`deno lint\` clean
- [x] \`deno check src/\` clean
- [x] \`deno task test\` — 323 passed (+10 new cases, +48 steps). The 6 pre-existing integration-test failures (require a local SurrealDB) are unchanged.

Internal callers migrated from the stub's \`Record<string, string>\` shape to the new structured types in \`src/test/schema_visualize.test.ts\` and \`src/test/integration_crud.test.ts\`.

Refs #12, closes #19.