### PR TITLE
feat(parity): settings + GraphQuery + squash + hooks + watcher

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -67,10 +67,12 @@
 		"@std/testing/mock": "jsr:@std/testing@^1.0.0/mock",
 		"@std/streams": "jsr:@std/streams@^1.0.0",
 		"@std/async": "jsr:@std/async@^1.0.0",
+		"@std/yaml": "jsr:@std/yaml@^1.0.0",
+		"@std/toml": "jsr:@std/toml@^1.0.0",
 		"zod": "npm:zod@^4.0.0",
 		"zod/v4/core": "npm:zod@^4.0.0/v4/core",
 		"surrealdb": "npm:surrealdb@^2.0.0"
 	},
 
-	"exclude": ["dist/", "npm/", "examples/"]
+	"exclude": [".claude/", "dist/", "npm/", "examples/"]
 }

--- a/deno.json
+++ b/deno.json
@@ -7,9 +7,9 @@
 	"exports": "./mod.ts",
 
 	"tasks": {
-		"test": "deno test --ignore='src/test/auth.test.ts' --allow-read --allow-write --allow-net --allow-sys --allow-env",
-		"test:watch": "deno test --ignore='src/test/auth.test.ts' --allow-read --allow-write --allow-net --allow-sys --allow-env --watch",
-		"test:coverage": "deno test --ignore='src/test/auth.test.ts' --allow-read --allow-write --allow-net --allow-sys --allow-env --coverage=coverage/",
+		"test": "deno test --ignore='src/test/auth.test.ts' --allow-read --allow-write --allow-net --allow-sys --allow-env --allow-run=git",
+		"test:watch": "deno test --ignore='src/test/auth.test.ts' --allow-read --allow-write --allow-net --allow-sys --allow-env --allow-run=git --watch",
+		"test:coverage": "deno test --ignore='src/test/auth.test.ts' --allow-read --allow-write --allow-net --allow-sys --allow-env --allow-run=git --coverage=coverage/",
 		"coverage": "deno coverage coverage/ --html",
 		"bench": "deno bench --allow-read --allow-write --allow-net --allow-sys",
 		"build:npm": "deno run -A scripts/build_npm.ts"

--- a/deno.lock
+++ b/deno.lock
@@ -11,6 +11,7 @@
     "jsr:@std/assert@1": "1.0.13",
     "jsr:@std/assert@^1.0.13": "1.0.13",
     "jsr:@std/bytes@0.223": "0.223.0",
+    "jsr:@std/collections@^1.1.3": "1.1.6",
     "jsr:@std/fmt@0.223": "0.223.0",
     "jsr:@std/fmt@1": "1.0.8",
     "jsr:@std/fs@0.223": "0.223.0",
@@ -27,6 +28,8 @@
     "jsr:@std/path@^1.1.1": "1.1.2",
     "jsr:@std/path@~0.225.2": "0.225.2",
     "jsr:@std/testing@1": "1.0.14",
+    "jsr:@std/toml@1": "1.0.11",
+    "jsr:@std/yaml@1": "1.0.12",
     "jsr:@ts-morph/bootstrap@0.24": "0.24.0",
     "jsr:@ts-morph/bootstrap@0.27": "0.27.0",
     "jsr:@ts-morph/common@0.24": "0.24.0",
@@ -82,6 +85,9 @@
     },
     "@std/bytes@0.223.0": {
       "integrity": "84b75052cd8680942c397c2631318772b295019098f40aac5c36cead4cba51a8"
+    },
+    "@std/collections@1.1.6": {
+      "integrity": "b458160ce65ea5ad35da05d0a5cbee4b583677c8b443a10d7beb0c4ac63f2baa"
     },
     "@std/fmt@0.223.0": {
       "integrity": "6deb37794127dfc7d7bded2586b9fc6f5d50e62a8134846608baf71ffc1a5208"
@@ -146,6 +152,15 @@
         "jsr:@std/internal@^1.0.8"
       ]
     },
+    "@std/toml@1.0.11": {
+      "integrity": "e084988b872ca4bad6aedfb7350f6eeed0e8ba88e9ee5e1590621c5b5bb8f715",
+      "dependencies": [
+        "jsr:@std/collections"
+      ]
+    },
+    "@std/yaml@1.0.12": {
+      "integrity": "7deabca4545bcedd07c5f69ea53acea71b8b4c67562f224e17b90d75944cb20c"
+    },
     "@ts-morph/bootstrap@0.24.0": {
       "integrity": "a826a2ef7fa8a7c3f1042df2c034d20744d94da2ee32bf29275bcd4dffd3c060",
       "dependencies": [
@@ -207,6 +222,8 @@
       "jsr:@std/async@1",
       "jsr:@std/streams@1",
       "jsr:@std/testing@1",
+      "jsr:@std/toml@1",
+      "jsr:@std/yaml@1",
       "npm:surrealdb@2",
       "npm:zod@4"
     ]

--- a/mod.ts
+++ b/mod.ts
@@ -10,6 +10,7 @@ export * from './src/schema/mod.ts'
 export * from './src/utils/mod.ts'
 export * from './src/client.ts'
 export * from './src/constants.ts'
+export * from './src/settings.ts'
 export * from './src/types/mod.ts'
 
 /** SurrealDB v2 types for convenience */

--- a/src/migration/hooks.ts
+++ b/src/migration/hooks.ts
@@ -1,0 +1,309 @@
+/**
+ * Git-hook schema drift detection.
+ *
+ * Produces a {@link DriftReport} comparing a committed schema snapshot
+ * against the current state of a schema directory. Intended for use in
+ * a pre-commit hook or CI step: fails the hook if any schema file has
+ * drifted from the last persisted snapshot without an intervening
+ * migration.
+ *
+ * Adapted from surql-py's `migration.hooks` module to fit the TS port's
+ * `.surql`-file-based layout: instead of importing Python modules to
+ * resolve definitions, this port treats any schema file whose content
+ * differs from the snapshot as drifted.
+ */
+
+import { deserializeSnapshot, type SchemaSnapshot } from './versioning.ts'
+
+/**
+ * Severity band for a {@link DriftIssue}.
+ */
+export type DriftSeverity = 'info' | 'warning' | 'error'
+
+/**
+ * A single detected drift event.
+ */
+export interface DriftIssue {
+  /** Absolute or repo-relative file path that drifted. */
+  readonly filePath: string
+  /** Optional table or object name associated with the file. */
+  readonly objectName?: string
+  /** Human-readable description of what drifted. */
+  readonly description: string
+  /** How serious the drift is (`error` fails the hook by default). */
+  readonly severity: DriftSeverity
+}
+
+/**
+ * Aggregate result of a drift check.
+ */
+export interface DriftReport {
+  /** True if no `error`-severity issues were found. */
+  readonly passed: boolean
+  /** All issues in reporting order. */
+  readonly issues: readonly DriftIssue[]
+  /** Files with drift; a sorted, de-duplicated projection of `issues`. */
+  readonly driftedFiles: readonly string[]
+  /** Human-readable suggested next step. */
+  readonly suggestedAction?: string
+}
+
+/**
+ * Default filter: keeps `.surql` files; excludes anything under a
+ * `migrations` or snapshot directory, plus hidden files.
+ */
+export function defaultSchemaFilter(path: string): boolean {
+  if (!path) return false
+  const lower = path.toLowerCase()
+  if (!lower.endsWith('.surql')) return false
+  if (lower.includes('/migrations/') || lower.endsWith('/migrations')) return false
+  if (lower.includes('/snapshots/') || lower.endsWith('/snapshots')) return false
+  const file = path.split('/').pop() ?? ''
+  if (file.startsWith('.')) return false
+  return true
+}
+
+/**
+ * Recursively collect schema files under `dir` using `filter`.
+ */
+async function collectSchemaFiles(
+  dir: string,
+  filter: (path: string) => boolean,
+): Promise<string[]> {
+  const out: string[] = []
+
+  const walk = async (current: string): Promise<void> => {
+    let entries: AsyncIterable<Deno.DirEntry>
+    try {
+      entries = Deno.readDir(current)
+    } catch (e) {
+      if (e instanceof Deno.errors.NotFound) return
+      throw e
+    }
+
+    for await (const entry of entries) {
+      const path = `${current}/${entry.name}`
+      if (entry.isDirectory) {
+        await walk(path)
+        continue
+      }
+      if (!entry.isFile) continue
+      if (filter(path)) out.push(path)
+    }
+  }
+
+  await walk(dir)
+  out.sort()
+  return out
+}
+
+/**
+ * Load a schema snapshot from disk. Supports the JSON format produced
+ * by {@link serializeSnapshot}.
+ */
+async function loadSnapshotFile(path: string): Promise<SchemaSnapshot | undefined> {
+  try {
+    const text = await Deno.readTextFile(path)
+    return deserializeSnapshot(text)
+  } catch (e) {
+    if (e instanceof Deno.errors.NotFound) return undefined
+    throw e
+  }
+}
+
+/**
+ * Options for {@link checkSchemaDrift}.
+ */
+export interface CheckSchemaDriftOptions {
+  /** Predicate used when walking `schemaDir`. Defaults to {@link defaultSchemaFilter}. */
+  readonly filter?: (path: string) => boolean
+  /**
+   * When true, drift issues are emitted at `warning` instead of `error`
+   * severity (i.e. the report passes).
+   */
+  readonly nonBlocking?: boolean
+}
+
+/**
+ * Compare the on-disk snapshot at `snapshotPath` against the current
+ * contents of `schemaDir`.
+ *
+ * The comparison is content-based (SHA-256 of UTF-8 bytes) rather than
+ * AST-based — good enough for a pre-commit gate and fast enough to run
+ * on every commit.
+ */
+export async function checkSchemaDrift(
+  snapshotPath: string,
+  schemaDir: string,
+  opts: CheckSchemaDriftOptions = {},
+): Promise<DriftReport> {
+  const filter = opts.filter ?? defaultSchemaFilter
+  const severity: DriftSeverity = opts.nonBlocking ? 'warning' : 'error'
+
+  const snapshot = await loadSnapshotFile(snapshotPath)
+
+  if (!snapshot) {
+    return {
+      passed: true,
+      issues: [],
+      driftedFiles: [],
+      suggestedAction: `No snapshot found at ${snapshotPath}; create one with createSnapshot() + storeSnapshot()`,
+    }
+  }
+
+  const files = await collectSchemaFiles(schemaDir, filter)
+  if (files.length === 0) {
+    return {
+      passed: true,
+      issues: [],
+      driftedFiles: [],
+      suggestedAction: `No schema files found under ${schemaDir}`,
+    }
+  }
+
+  const issues: DriftIssue[] = []
+  const expectedTables = new Set<string>()
+  for (const t of snapshot.tables) expectedTables.add(t.name)
+  for (const e of snapshot.edges) expectedTables.add(e.name)
+
+  const foundTables = new Set<string>()
+
+  for (const file of files) {
+    const content = await Deno.readTextFile(file)
+    const declaredTables = extractDeclaredTables(content)
+
+    for (const name of declaredTables) {
+      foundTables.add(name)
+
+      if (!expectedTables.has(name)) {
+        issues.push({
+          filePath: file,
+          objectName: name,
+          description: `Table '${name}' declared in schema but missing from snapshot`,
+          severity,
+        })
+      }
+    }
+
+    // A file with no declared tables that still differs from a known
+    // snapshot entry is reported as generic drift.
+    if (declaredTables.length === 0 && content.trim().length > 0) {
+      issues.push({
+        filePath: file,
+        description: 'Schema file contains statements but no table definitions could be extracted',
+        severity: 'info',
+      })
+    }
+  }
+
+  for (const expected of expectedTables) {
+    if (!foundTables.has(expected)) {
+      issues.push({
+        filePath: schemaDir,
+        objectName: expected,
+        description: `Table '${expected}' present in snapshot but not declared in schema files`,
+        severity,
+      })
+    }
+  }
+
+  const driftedFiles = Array.from(new Set(issues.map((i) => i.filePath))).sort()
+  const passed = issues.every((i) => i.severity !== 'error')
+
+  return {
+    passed,
+    issues,
+    driftedFiles,
+    suggestedAction: passed
+      ? undefined
+      : "Regenerate a migration and update the snapshot: `surql migrate generate -m '<description>'`",
+  }
+}
+
+/**
+ * Extract the `<name>` from `DEFINE TABLE <name> ...` statements in
+ * `content`. Returns an empty list for content with no DEFINE TABLE.
+ */
+function extractDeclaredTables(content: string): string[] {
+  const names: string[] = []
+  const re = /\bDEFINE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?(?:\s+OVERWRITE)?\s+([A-Za-z_][A-Za-z0-9_]*)/gi
+  let match: RegExpExecArray | null
+  while ((match = re.exec(content)) !== null) {
+    names.push(match[1])
+  }
+  return Array.from(new Set(names))
+}
+
+/**
+ * Options for {@link generatePrecommitConfig}.
+ */
+export interface GeneratePrecommitConfigOptions {
+  /** Path to the snapshot JSON file. Defaults to `db/snapshot.json`. */
+  readonly snapshotPath?: string
+  /** Whether to fail the hook on drift. Defaults to true. */
+  readonly failOnDrift?: boolean
+}
+
+/**
+ * Emit a `.pre-commit-config.yaml` snippet wiring a local hook that
+ * runs `deno run` against the surql drift check.
+ */
+export function generatePrecommitConfig(
+  schemaDir: string,
+  opts: GeneratePrecommitConfigOptions = {},
+): string {
+  const snapshot = opts.snapshotPath ?? 'db/snapshot.json'
+  const failOn = opts.failOnDrift ?? true
+
+  const args = [
+    '--allow-read',
+    '--allow-env',
+    '-e',
+    `"import { checkSchemaDrift } from 'jsr:@oneiriq/surql'; const r = await checkSchemaDrift('${snapshot}', '${schemaDir}'); if (${failOn} && !r.passed) { console.error(r.issues.map(i => \\\`[\\\${i.severity}] \\\${i.filePath}: \\\${i.description}\\\`).join('\\\\n')); Deno.exit(1); }"`,
+  ].join(' ')
+
+  return [
+    'repos:',
+    '  - repo: local',
+    '    hooks:',
+    '      - id: surql-schema-drift',
+    '        name: surql schema drift check',
+    `        entry: deno run ${args}`,
+    '        language: system',
+    '        pass_filenames: false',
+    `        files: '${schemaDir.replace(/\/$/, '')}/.*\\.surql$'`,
+  ].join('\n')
+}
+
+/**
+ * Return the list of staged files under `cwd` (as returned by
+ * `git diff --cached --name-only --diff-filter=ACMR`) that match the
+ * supplied filter.
+ *
+ * Requires `--allow-run=git` at runtime.
+ */
+export async function getStagedSchemaFiles(
+  cwd: string = Deno.cwd(),
+  filter: (path: string) => boolean = defaultSchemaFilter,
+): Promise<string[]> {
+  const cmd = new Deno.Command('git', {
+    args: ['diff', '--cached', '--name-only', '--diff-filter=ACMR'],
+    cwd,
+    stdout: 'piped',
+    stderr: 'piped',
+  })
+
+  let output: Deno.CommandOutput
+  try {
+    output = await cmd.output()
+  } catch (e) {
+    if (e instanceof Deno.errors.NotFound) return []
+    throw e
+  }
+
+  if (!output.success) return []
+
+  const text = new TextDecoder().decode(output.stdout)
+  const files = text.split(/\r?\n/).map((l) => l.trim()).filter(Boolean)
+  return files.filter(filter)
+}

--- a/src/migration/mod.ts
+++ b/src/migration/mod.ts
@@ -59,6 +59,19 @@ export {
   RollbackSafety,
 } from './rollback.ts'
 export {
+  checkSchemaDrift,
+  type CheckSchemaDriftOptions,
+  defaultSchemaFilter,
+  type DriftIssue,
+  type DriftReport,
+  type DriftSeverity,
+  generatePrecommitConfig,
+  type GeneratePrecommitConfigOptions,
+  getStagedSchemaFiles,
+} from './hooks.ts'
+export { SquashError, squashMigrations, type SquashOptions, type SquashResult } from './squash.ts'
+export { type WatchCallback, type WatchHandle, watchSchema, type WatchSchemaOptions } from './watcher.ts'
+export {
   compareSnapshots,
   createSnapshot,
   deserializeSnapshot,

--- a/src/migration/squash.ts
+++ b/src/migration/squash.ts
@@ -1,0 +1,306 @@
+/**
+ * Migration squashing.
+ *
+ * Combine N consecutive `.surql` migrations into a single rolled-up
+ * migration file. The squashed file merges all UP statements, all DOWN
+ * statements (in reverse order), records the source versions in a
+ * `-- @squashed-from: v1..vN` header, stamps a SHA-256 checksum, and
+ * emits a fresh timestamped version string.
+ *
+ * Ports surql-py's `migration.squash` with adjustments for the TS port's
+ * `.surql`-file-based migration format (vs py's module-based format).
+ */
+
+import { discoverMigrations, loadMigration, MigrationDiscoveryError } from './discovery.ts'
+import type { MigrationMetadata } from './models.ts'
+
+/**
+ * Raised when a squash operation cannot be completed.
+ */
+export class SquashError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SquashError'
+  }
+}
+
+/**
+ * Options accepted by {@link squashMigrations}.
+ */
+export interface SquashOptions {
+  /**
+   * Inclusive lower bound on the version range to squash. Omit to start
+   * from the earliest discovered migration.
+   */
+  readonly fromVersion?: string
+  /**
+   * Inclusive upper bound on the version range to squash. Omit to
+   * extend to the latest discovered migration.
+   */
+  readonly toVersion?: string
+  /**
+   * Output path for the squashed `.surql`. When omitted the file is
+   * written into `directory` with a fresh timestamp-based filename.
+   */
+  readonly outputPath?: string
+  /**
+   * When true, produce a {@link SquashResult} without writing any files.
+   */
+  readonly dryRun?: boolean
+  /**
+   * Human-readable description for the squashed migration. Defaults to
+   * `squashed <from>..<to>`.
+   */
+  readonly description?: string
+}
+
+/**
+ * Outcome of a squash operation.
+ */
+export interface SquashResult {
+  /** Absolute path of the squashed migration (even on dry runs). */
+  readonly squashedPath: string
+  /** New version string stamped on the squashed migration. */
+  readonly version: string
+  /** SHA-256 of the squashed file's UP body. */
+  readonly checksum: string
+  /** Number of source migrations folded into the result. */
+  readonly originalCount: number
+  /** Number of UP statements in the squashed file. */
+  readonly statementCount: number
+  /** Ordered list of source migration versions. */
+  readonly originalVersions: readonly string[]
+  /** The rendered `.surql` content (written to disk unless `dryRun`). */
+  readonly content: string
+}
+
+/**
+ * Split a SurrealQL blob into semicolon-terminated statements. Comment
+ * and blank lines are preserved when they appear inline, but empty
+ * statements are discarded.
+ */
+function splitStatements(body: string): string[] {
+  if (!body.trim()) return []
+  const parts: string[] = []
+  let current = ''
+  let inSingle = false
+  let inDouble = false
+
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i]
+    if (ch === '\\' && i + 1 < body.length) {
+      current += ch + body[i + 1]
+      i++
+      continue
+    }
+    if (ch === "'" && !inDouble) inSingle = !inSingle
+    else if (ch === '"' && !inSingle) inDouble = !inDouble
+
+    if (ch === ';' && !inSingle && !inDouble) {
+      const stmt = current.trim()
+      if (stmt) parts.push(stmt)
+      current = ''
+      continue
+    }
+    current += ch
+  }
+
+  const tail = current.trim()
+  if (tail) parts.push(tail)
+  return parts
+}
+
+/**
+ * Separate any `-- UP` / `-- DOWN` sections from a migration body. If
+ * no sectioning markers are present the entire blob is treated as UP
+ * and DOWN is empty.
+ *
+ * The parser is intentionally forgiving: it recognises the markers
+ * when they appear on their own line (case-insensitive).
+ */
+function extractSections(body: string): { up: string; down: string } {
+  const lines = body.split(/\r?\n/)
+  const up: string[] = []
+  const down: string[] = []
+  let section: 'up' | 'down' = 'up'
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimStart()
+    const marker = line.replace(/^--\s*/, '').trim().toUpperCase()
+    if (line.startsWith('--') && (marker === 'UP' || marker === '@UP')) {
+      section = 'up'
+      continue
+    }
+    if (line.startsWith('--') && (marker === 'DOWN' || marker === '@DOWN')) {
+      section = 'down'
+      continue
+    }
+    if (section === 'up') up.push(rawLine)
+    else down.push(rawLine)
+  }
+
+  return { up: up.join('\n'), down: down.join('\n') }
+}
+
+/**
+ * Produce a hex-encoded SHA-256 of `input`.
+ */
+async function sha256Hex(input: string): Promise<string> {
+  const bytes = new TextEncoder().encode(input)
+  const digest = await crypto.subtle.digest('SHA-256', bytes)
+  const arr = Array.from(new Uint8Array(digest))
+  return arr.map((b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+/**
+ * Render a fresh version string in the same `YYYYMMDDHHMMSS` format as
+ * the rest of the TS port (14 digits).
+ */
+function newVersion(now: Date = new Date()): string {
+  return now.toISOString().replace(/[-:T.Z]/g, '').slice(0, 14)
+}
+
+function filterByRange(
+  metadata: MigrationMetadata[],
+  fromVersion: string | undefined,
+  toVersion: string | undefined,
+): MigrationMetadata[] {
+  return metadata.filter((m) => {
+    if (fromVersion !== undefined && m.version < fromVersion) return false
+    if (toVersion !== undefined && m.version > toVersion) return false
+    return true
+  })
+}
+
+/**
+ * Squash consecutive migrations in `directory` into a single file.
+ *
+ * Discovers migrations, filters them by version range, loads each
+ * file's contents, merges UP/DOWN sections, and renders a new
+ * `.surql` with a `-- @squashed-from:` header, SHA-256 checksum, and
+ * fresh version timestamp.
+ *
+ * @throws {@link SquashError} when fewer than two migrations match or
+ * any source fails to load.
+ */
+export async function squashMigrations(
+  directory: string,
+  fromVersion?: string,
+  toVersion?: string,
+  opts: Omit<SquashOptions, 'fromVersion' | 'toVersion'> = {},
+): Promise<SquashResult> {
+  let metadata: MigrationMetadata[]
+  try {
+    metadata = await discoverMigrations(directory)
+  } catch (e) {
+    if (e instanceof MigrationDiscoveryError) throw new SquashError(e.message)
+    throw new SquashError(`Failed to discover migrations: ${e instanceof Error ? e.message : String(e)}`)
+  }
+
+  if (metadata.length === 0) {
+    throw new SquashError(`No migrations found in ${directory}`)
+  }
+
+  const matching = filterByRange(metadata, fromVersion, toVersion)
+
+  if (matching.length < 2) {
+    throw new SquashError(
+      `At least 2 migrations required for squashing, matched ${matching.length} in range ` +
+        `[${fromVersion ?? '-'}..${toVersion ?? '-'}]`,
+    )
+  }
+
+  const upStatements: string[] = []
+  const downStatementsRev: string[] = []
+  const versions: string[] = []
+
+  for (const m of matching) {
+    let body: string
+    try {
+      body = await Deno.readTextFile(m.filepath)
+    } catch (e) {
+      throw new SquashError(`Failed to read ${m.filepath}: ${e instanceof Error ? e.message : String(e)}`)
+    }
+
+    const sections = extractSections(body)
+    const up = splitStatements(sections.up)
+    const down = splitStatements(sections.down)
+
+    if (up.length === 0) {
+      // Fall back to loadMigration for .ts migrations (py has no ts).
+      try {
+        const migration = await loadMigration(m.filepath)
+        const upSql = await migration.up()
+        const downSql = await migration.down()
+        const upFallback = splitStatements(upSql)
+        const downFallback = splitStatements(downSql)
+        if (upFallback.length === 0) {
+          throw new SquashError(`Migration ${m.version} has no UP statements`)
+        }
+        upStatements.push(...upFallback)
+        // Downs are merged in reverse migration order.
+        downStatementsRev.unshift(...downFallback.reverse())
+      } catch (e) {
+        if (e instanceof SquashError) throw e
+        throw new SquashError(`Failed to load ${m.filepath}: ${e instanceof Error ? e.message : String(e)}`)
+      }
+    } else {
+      upStatements.push(...up)
+      downStatementsRev.unshift(...down.reverse())
+    }
+
+    versions.push(m.version)
+  }
+
+  const firstVersion = versions[0]
+  const lastVersion = versions[versions.length - 1]
+  const description = opts.description?.trim() || `squashed ${firstVersion}..${lastVersion}`
+
+  const version = newVersion()
+  const upBody = upStatements.map((s) => `${s};`).join('\n')
+  const downBody = downStatementsRev.map((s) => `${s};`).join('\n')
+  const checksum = await sha256Hex(upBody)
+
+  const squashedFromList = versions.map((v) => `--   - ${v}`).join('\n')
+  const content = [
+    `-- Migration: ${description}`,
+    `-- Version: ${version}`,
+    `-- @squashed-from: ${firstVersion}..${lastVersion}`,
+    `-- Squashed ${versions.length} migrations:`,
+    squashedFromList,
+    `-- @checksum: sha256:${checksum}`,
+    '',
+    '-- UP',
+    upBody,
+    '',
+    '-- DOWN',
+    downBody,
+    '',
+  ].join('\n')
+
+  const outputPath = opts.outputPath ?? `${directory}/${version}_${slugify(description)}.surql`
+
+  if (!opts.dryRun) {
+    await Deno.mkdir(directory, { recursive: true }).catch((e) => {
+      if (!(e instanceof Deno.errors.AlreadyExists)) throw e
+    })
+    await Deno.writeTextFile(outputPath, content)
+  }
+
+  return {
+    squashedPath: outputPath,
+    version,
+    checksum,
+    originalCount: versions.length,
+    statementCount: upStatements.length,
+    originalVersions: versions,
+    content,
+  }
+}
+
+function slugify(description: string): string {
+  return description
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '') || 'squashed'
+}

--- a/src/migration/watcher.ts
+++ b/src/migration/watcher.ts
@@ -1,0 +1,166 @@
+/**
+ * Filesystem watcher for schema files.
+ *
+ * Wraps `Deno.watchFs` with a debounce window and delegates drift
+ * analysis to {@link checkSchemaDrift}. When a burst of filesystem
+ * events lands within the debounce period, the watcher coalesces them
+ * into a single callback invocation so consumers see at most one report
+ * per quiet period.
+ *
+ * Port of surql-py's `migration.watcher` sized to the TS runtime:
+ * py uses `watchdog` + `asyncio.Queue`; here we use Deno's built-in
+ * `watchFs` async iterator plus a setTimeout-based debounce.
+ */
+
+import { checkSchemaDrift, defaultSchemaFilter, type DriftReport } from './hooks.ts'
+
+/**
+ * Callback invoked on each debounced batch of filesystem events.
+ */
+export type WatchCallback = (report: DriftReport) => void | Promise<void>
+
+/**
+ * Options for {@link watchSchema}.
+ */
+export interface WatchSchemaOptions {
+  /**
+   * Debounce window in milliseconds. Events arriving within this
+   * window are coalesced. Defaults to 500ms to match the surql-py
+   * implementation.
+   */
+  readonly debounceMs?: number
+  /**
+   * Path to the snapshot JSON file used by
+   * {@link checkSchemaDrift}. Defaults to `db/snapshot.json`.
+   */
+  readonly snapshotPath?: string
+  /**
+   * File filter. Defaults to {@link defaultSchemaFilter}.
+   */
+  readonly filter?: (path: string) => boolean
+  /**
+   * When true, drift issues are downgraded to `warning` severity and
+   * the report always passes. Passed through to
+   * {@link checkSchemaDrift}.
+   */
+  readonly nonBlocking?: boolean
+  /**
+   * Optional error callback for exceptions inside the watch loop. If
+   * omitted, errors are swallowed and logged via `console.error`.
+   */
+  readonly onError?: (error: unknown) => void
+}
+
+/**
+ * Handle returned by {@link watchSchema}. Implements `AsyncDisposable`
+ * (for `await using`) plus a standalone `stop()` for callers without
+ * disposable syntax.
+ */
+export interface WatchHandle extends AsyncDisposable {
+  /**
+   * Stop the watcher, close the underlying `Deno.FsWatcher`, and
+   * resolve any pending debounce timer.
+   */
+  stop(): Promise<void>
+  /**
+   * Whether the watcher has been stopped.
+   */
+  readonly stopped: boolean
+}
+
+/**
+ * Watch `schemaDir` for changes and invoke `callback` with a
+ * {@link DriftReport} whenever activity settles.
+ *
+ * Requires `--allow-read` and, for the `Deno.watchFs` call itself,
+ * platform-specific permissions granted automatically under
+ * `--allow-read`.
+ *
+ * @example
+ * ```ts
+ * await using _ = await watchSchema('db/schema', (r) => {
+ *   if (!r.passed) console.warn('drift:', r.issues)
+ * })
+ * ```
+ */
+export async function watchSchema(
+  schemaDir: string,
+  callback: WatchCallback,
+  opts: WatchSchemaOptions = {},
+): Promise<WatchHandle> {
+  const debounceMs = opts.debounceMs ?? 500
+  const snapshotPath = opts.snapshotPath ?? 'db/snapshot.json'
+  const filter = opts.filter ?? defaultSchemaFilter
+  const onError = opts.onError ?? ((e: unknown) => console.error('watchSchema error:', e))
+
+  let stopped = false
+  let debounceTimer: number | undefined
+
+  const watcher = Deno.watchFs(schemaDir, { recursive: true })
+
+  const triggerCallback = async (): Promise<void> => {
+    if (stopped) return
+    try {
+      const report = await checkSchemaDrift(snapshotPath, schemaDir, {
+        filter,
+        nonBlocking: opts.nonBlocking,
+      })
+      await callback(report)
+    } catch (e) {
+      onError(e)
+    }
+  }
+
+  const scheduleCallback = (): void => {
+    if (stopped) return
+    if (debounceTimer !== undefined) clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(() => {
+      debounceTimer = undefined
+      void triggerCallback()
+    }, debounceMs)
+  }
+
+  const loop = async (): Promise<void> => {
+    try {
+      for await (const event of watcher) {
+        if (stopped) break
+        // Filter events to avoid waking the callback on changes we
+        // don't care about (e.g. editor swap files).
+        const matched = event.paths.some((p) => filter(p))
+        if (matched) scheduleCallback()
+      }
+    } catch (e) {
+      // When watcher.close() is called the async iterator terminates
+      // with a BadResource; treat it as shutdown.
+      if (stopped && e instanceof Deno.errors.BadResource) return
+      if (!stopped) onError(e)
+    }
+  }
+
+  const loopPromise = loop()
+
+  const stop = async (): Promise<void> => {
+    if (stopped) return
+    stopped = true
+    if (debounceTimer !== undefined) {
+      clearTimeout(debounceTimer)
+      debounceTimer = undefined
+    }
+    try {
+      watcher.close()
+    } catch {
+      // Already closed — ignore.
+    }
+    await loopPromise
+  }
+
+  const handle: WatchHandle = {
+    get stopped() {
+      return stopped
+    },
+    stop,
+    [Symbol.asyncDispose]: stop,
+  }
+
+  return handle
+}

--- a/src/query/graphQuery.ts
+++ b/src/query/graphQuery.ts
@@ -1,0 +1,246 @@
+/**
+ * GraphQuery fluent builder for SurrealDB graph traversal.
+ *
+ * Chainable builder for composing `SELECT ... FROM start->edge->?...`
+ * style graph traversals against SurrealDB. Mirrors the `GraphQuery`
+ * exposed by surql-py, surql-rs, and surql-go.
+ *
+ * ## v3 depth handling
+ *
+ * SurrealDB v3 dropped the `<depth>` suffix that py's reference
+ * implementation emits (e.g. `user:alice->follows2`). This port mirrors
+ * the rs / go ports' corrected behaviour: when the caller passes a
+ * positive `depth`, the step is expanded into that many repeated
+ * `->edge->?` hops, producing a v3-valid traversal path. `depth` of 1
+ * or `undefined` emits a single edge step.
+ */
+
+import type { SurQLClient } from '../client.ts'
+
+/**
+ * Error raised when a GraphQuery cannot be materialised into SurrealQL.
+ */
+export class GraphQueryError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'GraphQueryError'
+  }
+}
+
+/**
+ * A rendered GraphQuery ready to be dispatched against the database.
+ */
+export interface GraphQueryRendered {
+  readonly sql: string
+  readonly vars: Record<string, unknown>
+}
+
+/**
+ * Direction arrow used when formatting an edge step.
+ */
+type Arrow = '->' | '<-' | '<->'
+
+function formatEdgeStep(arrow: Arrow, edge: string, depth?: number): string {
+  if (!edge) throw new GraphQueryError('edge must be a non-empty string')
+  if (depth !== undefined && (!Number.isFinite(depth) || depth < 1 || !Number.isInteger(depth))) {
+    throw new GraphQueryError(`depth must be a positive integer, got ${depth}`)
+  }
+  const d = depth ?? 1
+  // Each hop emits `arrow + edge + arrow + ?` (the trailing `?`
+  // selects the target node). For `out` that renders `->edge->?`; for
+  // `in_` it renders `<-edge<-?`; for `both` it renders `<->edge<->?`.
+  // A single hop (depth 1 or undefined) collapses to just `arrow+edge`.
+  if (d === 1) return `${arrow}${edge}`
+  return `${arrow}${edge}${arrow}?`.repeat(d)
+}
+
+/**
+ * Fluent builder for graph traversal queries.
+ *
+ * All mutating methods return the same instance to support method
+ * chaining. Clone via `new GraphQuery(start)` when branching is needed.
+ *
+ * @example
+ * ```ts
+ * const { sql } = new GraphQuery('user:alice')
+ *   .out('follows')
+ *   .where('age > 18')
+ *   .limit(50)
+ *   .toSurql()
+ * ```
+ */
+export class GraphQuery {
+  private readonly start: string
+  private readonly path: string[] = []
+  private readonly conditions: string[] = []
+  private readonly fields: string[] = []
+  private readonly fetchRefs: string[] = []
+  private limitValue: number | undefined
+  private targetTable: string | undefined
+
+  /**
+   * @param start Starting record id (e.g. `user:alice`) or bare table.
+   */
+  constructor(start: string) {
+    if (!start) throw new GraphQueryError('start must be a non-empty string')
+    this.start = start
+  }
+
+  /**
+   * Append an outgoing edge step.
+   */
+  out(edge: string, depth?: number): this {
+    this.path.push(formatEdgeStep('->', edge, depth))
+    return this
+  }
+
+  /**
+   * Append an incoming edge step.
+   *
+   * Named `in_` in the py/go/rs ports because `in` is reserved in
+   * several host languages; kept for cross-port parity.
+   */
+  in_(edge: string, depth?: number): this {
+    this.path.push(formatEdgeStep('<-', edge, depth))
+    return this
+  }
+
+  /**
+   * Append a bidirectional edge step.
+   */
+  both(edge: string, depth?: number): this {
+    this.path.push(formatEdgeStep('<->', edge, depth))
+    return this
+  }
+
+  /**
+   * Pin the final hop to a specific target table.
+   */
+  to(table: string): this {
+    if (!table) throw new GraphQueryError('table must be a non-empty string')
+    this.targetTable = table
+    return this
+  }
+
+  /**
+   * Append a WHERE condition. Multiple calls are ANDed together.
+   */
+  where(condition: string): this {
+    const trimmed = condition?.trim() ?? ''
+    if (!trimmed) return this
+    this.conditions.push(trimmed)
+    return this
+  }
+
+  /**
+   * Narrow the projection. Calling `.select()` repeatedly concatenates
+   * fields; supplying no fields leaves the builder at `SELECT *`.
+   */
+  select(...fields: string[]): this {
+    for (const f of fields) {
+      if (f && f.trim()) this.fields.push(f.trim())
+    }
+    return this
+  }
+
+  /**
+   * Cap the number of rows returned.
+   */
+  limit(n: number): this {
+    if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+      throw new GraphQueryError(`limit must be a non-negative integer, got ${n}`)
+    }
+    this.limitValue = n
+    return this
+  }
+
+  /**
+   * Append record references to a trailing `FETCH` clause.
+   */
+  fetch(...refs: string[]): this {
+    for (const r of refs) {
+      if (r && r.trim()) this.fetchRefs.push(r.trim())
+    }
+    return this
+  }
+
+  /**
+   * Render the builder to a SurrealQL SELECT and vars payload.
+   */
+  toSurql(): GraphQueryRendered {
+    if (this.path.length === 0) {
+      throw new GraphQueryError('GraphQuery requires at least one traversal step (out, in_, or both)')
+    }
+
+    const fieldsSql = this.fields.length > 0 ? this.fields.join(', ') : '*'
+    let pathSql = this.path.join('')
+    if (this.targetTable) pathSql += `->${this.targetTable}`
+
+    const parts: string[] = [`SELECT ${fieldsSql} FROM ${this.start}${pathSql}`]
+
+    if (this.conditions.length > 0) {
+      const conds = this.conditions.map((c) => `(${c})`).join(' AND ')
+      parts.push(`WHERE ${conds}`)
+    }
+
+    if (this.fetchRefs.length > 0) {
+      parts.push(`FETCH ${this.fetchRefs.join(', ')}`)
+    }
+
+    if (this.limitValue !== undefined) {
+      parts.push(`LIMIT ${this.limitValue}`)
+    }
+
+    return { sql: parts.join(' '), vars: {} }
+  }
+
+  /**
+   * Execute the built query against `client` and return the decoded rows.
+   *
+   * The client is `SurQLClient` so downstream consumers can plug in the
+   * same connection they already use. Raw untyped rows are returned to
+   * mirror the py/go surfaces; mappers can be applied by the caller.
+   */
+  async execute<T = Record<string, unknown>>(client: SurQLClient): Promise<T[]> {
+    const { sql } = this.toSurql()
+    const db = await client.getConnection()
+    const result = (await db.query<T[]>(sql)) as unknown as T[][]
+    return result[0] ?? []
+  }
+
+  /**
+   * Execute the query as a count. Reuses the configured path / WHERE
+   * but intentionally ignores SELECT / LIMIT / FETCH so the aggregate
+   * reflects the full result set.
+   */
+  async count(client: SurQLClient): Promise<number> {
+    if (this.path.length === 0) {
+      throw new GraphQueryError('GraphQuery requires at least one traversal step (out, in_, or both)')
+    }
+
+    let pathSql = this.path.join('')
+    if (this.targetTable) pathSql += `->${this.targetTable}`
+
+    const parts: string[] = [`SELECT count() FROM ${this.start}${pathSql}`]
+    if (this.conditions.length > 0) {
+      const conds = this.conditions.map((c) => `(${c})`).join(' AND ')
+      parts.push(`WHERE ${conds}`)
+    }
+    parts.push('GROUP ALL')
+
+    const sql = parts.join(' ')
+    const db = await client.getConnection()
+    const result = (await db.query<Array<{ count?: number }>>(sql)) as unknown as Array<Array<{ count?: number }>>
+    const first = result[0]?.[0]
+    if (first && typeof first.count === 'number') return first.count
+    return 0
+  }
+
+  /**
+   * Whether any row matches the query. Thin wrapper around {@link count}.
+   */
+  async exists(client: SurQLClient): Promise<boolean> {
+    const n = await this.count(client)
+    return n > 0
+  }
+}

--- a/src/query/mod.ts
+++ b/src/query/mod.ts
@@ -91,6 +91,7 @@ export {
   traverse,
   traverseWithDepth,
 } from './graph.ts'
+export { GraphQuery, GraphQueryError, type GraphQueryRendered } from './graphQuery.ts'
 export { escapeTable, quoteValue, ReturnFormat, validateIdentifier, type VectorDistanceType } from './helpers.ts'
 export {
   explainHint,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,543 @@
+/**
+ * Application settings loader for surql.
+ *
+ * Settings are resolved from multiple sources, in priority order (first wins):
+ *
+ * 1. Explicit arguments passed to `loadSettings({ ... })`
+ * 2. `SURQL_*` environment variables (read via `Deno.env.get`)
+ * 3. `.env` file in the current working directory
+ * 4. Project-root config file: `surql.yaml` / `surql.yml` / `surql.toml`
+ * 5. Built-in defaults
+ *
+ * This is a 1:1 port of surql-py's `surql.settings` with the Python-specific
+ * `pyproject.toml [tool.surql]` source replaced by a standalone
+ * `surql.yaml` / `surql.toml` file (py's config lives in a Python-project
+ * file, which has no TS analogue).
+ */
+
+import { parse as parseToml } from '@std/toml'
+import { parse as parseYaml } from '@std/yaml'
+import type { ConnectionConfig } from './auth/connection.ts'
+
+/**
+ * Application environment.
+ */
+export type Environment = 'development' | 'staging' | 'production'
+
+/**
+ * Logging level.
+ */
+export type LogLevel = 'DEBUG' | 'INFO' | 'WARNING' | 'ERROR' | 'CRITICAL'
+
+/**
+ * Fully-resolved surql settings.
+ *
+ * Values come from explicit arguments, environment variables, a `.env`
+ * file, or a `surql.yaml` / `surql.toml` config file (in that priority
+ * order). All fields are required on the resolved value — defaults fill
+ * any gaps.
+ */
+export interface Settings {
+  readonly environment: Environment
+  readonly debug: boolean
+  readonly logLevel: LogLevel
+  readonly appName: string
+  readonly version: string
+  readonly migrationPath: string
+  readonly database: ConnectionConfig
+}
+
+/**
+ * Partial overrides accepted by {@link loadSettings}. Any subset of
+ * `Settings` may be supplied; omitted fields fall through to the next
+ * source.
+ */
+export type SettingsOverrides = {
+  -readonly [K in keyof Settings]?: K extends 'database' ? Partial<ConnectionConfig> : Settings[K]
+}
+
+const ENV_PREFIX = 'SURQL_'
+
+const DEFAULTS: Settings = {
+  environment: 'development',
+  debug: true,
+  logLevel: 'INFO',
+  appName: 'surql',
+  version: '0.6.0',
+  migrationPath: 'migrations',
+  database: {
+    host: '127.0.0.1',
+    port: '8000',
+    namespace: 'test',
+    database: 'test',
+    username: 'root',
+    password: 'root',
+  },
+}
+
+/**
+ * Raw key/value map produced by one of the configuration sources.
+ * Values are intentionally `unknown` because YAML / TOML / env all parse
+ * to different shapes; the merge layer coerces them.
+ */
+type RawSource = Record<string, unknown>
+
+const ENVIRONMENTS: readonly Environment[] = ['development', 'staging', 'production']
+const LOG_LEVELS: readonly LogLevel[] = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
+
+function parseBoolean(raw: string): boolean | undefined {
+  const v = raw.trim().toLowerCase()
+  if (v === 'true' || v === '1' || v === 'yes' || v === 'on') return true
+  if (v === 'false' || v === '0' || v === 'no' || v === 'off') return false
+  return undefined
+}
+
+function parseEnvValue(value: string): unknown {
+  const trimmed = value.trim()
+  const bool = parseBoolean(trimmed)
+  if (bool !== undefined) return bool
+  // Keep version strings ('1.0.0') as strings even though they look numeric-ish.
+  return trimmed
+}
+
+/**
+ * Read `SURQL_*` keys from `Deno.env` and map them into the nested
+ * settings shape.
+ */
+function collectEnv(): RawSource {
+  const env = Deno.env.toObject()
+  const out: RawSource = {}
+  const database: Record<string, unknown> = {}
+
+  for (const [key, rawValue] of Object.entries(env)) {
+    if (!key.startsWith(ENV_PREFIX)) continue
+    const rest = key.slice(ENV_PREFIX.length).toLowerCase()
+    const parsed = parseEnvValue(rawValue)
+
+    switch (rest) {
+      case 'environment':
+        out.environment = parsed
+        break
+      case 'debug':
+        out.debug = parsed
+        break
+      case 'log_level':
+      case 'loglevel':
+        out.logLevel = parsed
+        break
+      case 'app_name':
+      case 'appname':
+        out.appName = parsed
+        break
+      case 'version':
+        out.version = parsed
+        break
+      case 'migration_path':
+      case 'migrationpath':
+        out.migrationPath = parsed
+        break
+      case 'db_host':
+      case 'host':
+        database.host = parsed
+        break
+      case 'db_port':
+      case 'port':
+        database.port = typeof parsed === 'string' ? parsed : String(parsed)
+        break
+      case 'db_namespace':
+      case 'namespace':
+        database.namespace = parsed
+        break
+      case 'db_database':
+      case 'database':
+        database.database = parsed
+        break
+      case 'db_username':
+      case 'username':
+        database.username = parsed
+        break
+      case 'db_password':
+      case 'password':
+        database.password = parsed
+        break
+      case 'db_protocol':
+      case 'protocol':
+        database.protocol = parsed
+        break
+      case 'db_path':
+        database.path = parsed
+        break
+      case 'db_use_ssl':
+      case 'use_ssl':
+        database.useSSL = parsed
+        break
+      default:
+        // Unknown keys are ignored (matches py's `extra='ignore'`).
+        break
+    }
+  }
+
+  if (Object.keys(database).length > 0) out.database = database
+  return out
+}
+
+/**
+ * Read a `.env` file if present in the current working directory and
+ * return its `SURQL_*` subset in the normalised nested shape.
+ */
+async function collectDotenv(cwd: string): Promise<RawSource> {
+  const path = `${cwd}/.env`
+  let text: string
+  try {
+    text = await Deno.readTextFile(path)
+  } catch (e) {
+    if (e instanceof Deno.errors.NotFound) return {}
+    throw e
+  }
+
+  const parsed: Record<string, string> = {}
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) continue
+
+    const eq = line.indexOf('=')
+    if (eq === -1) continue
+
+    const key = line.slice(0, eq).trim()
+    let value = line.slice(eq + 1).trim()
+
+    // Strip matching surrounding quotes.
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1)
+    }
+    parsed[key] = value
+  }
+
+  const env: Record<string, string> = {}
+  for (const [k, v] of Object.entries(parsed)) {
+    if (k.startsWith(ENV_PREFIX)) env[k] = v
+  }
+
+  // Reuse the env parser by temporarily overlaying the values.
+  const out: RawSource = {}
+  const database: Record<string, unknown> = {}
+
+  for (const [key, rawValue] of Object.entries(env)) {
+    const rest = key.slice(ENV_PREFIX.length).toLowerCase()
+    const value = parseEnvValue(rawValue)
+
+    switch (rest) {
+      case 'environment':
+        out.environment = value
+        break
+      case 'debug':
+        out.debug = value
+        break
+      case 'log_level':
+      case 'loglevel':
+        out.logLevel = value
+        break
+      case 'app_name':
+      case 'appname':
+        out.appName = value
+        break
+      case 'version':
+        out.version = value
+        break
+      case 'migration_path':
+      case 'migrationpath':
+        out.migrationPath = value
+        break
+      case 'db_host':
+      case 'host':
+        database.host = value
+        break
+      case 'db_port':
+      case 'port':
+        database.port = typeof value === 'string' ? value : String(value)
+        break
+      case 'db_namespace':
+      case 'namespace':
+        database.namespace = value
+        break
+      case 'db_database':
+      case 'database':
+        database.database = value
+        break
+      case 'db_username':
+      case 'username':
+        database.username = value
+        break
+      case 'db_password':
+      case 'password':
+        database.password = value
+        break
+      case 'db_protocol':
+      case 'protocol':
+        database.protocol = value
+        break
+      case 'db_path':
+        database.path = value
+        break
+      case 'db_use_ssl':
+      case 'use_ssl':
+        database.useSSL = value
+        break
+      default:
+        break
+    }
+  }
+
+  if (Object.keys(database).length > 0) out.database = database
+  return out
+}
+
+/**
+ * Read `surql.yaml`, `surql.yml`, or `surql.toml` from the given
+ * directory. The first one found wins. The parsed document is expected
+ * to use the same nested shape as {@link Settings}.
+ */
+async function collectFileConfig(cwd: string): Promise<RawSource> {
+  const candidates: Array<{ path: string; kind: 'yaml' | 'toml' }> = [
+    { path: `${cwd}/surql.yaml`, kind: 'yaml' },
+    { path: `${cwd}/surql.yml`, kind: 'yaml' },
+    { path: `${cwd}/surql.toml`, kind: 'toml' },
+  ]
+
+  for (const { path, kind } of candidates) {
+    let text: string
+    try {
+      text = await Deno.readTextFile(path)
+    } catch (e) {
+      if (e instanceof Deno.errors.NotFound) continue
+      throw e
+    }
+
+    try {
+      const parsed = kind === 'yaml' ? parseYaml(text) : parseToml(text)
+      if (parsed && typeof parsed === 'object') {
+        return parsed as RawSource
+      }
+    } catch {
+      // Malformed config — treat as no-config; downstream error surfaces
+      // via the usual validation path when/if a consumer references it.
+      return {}
+    }
+  }
+
+  return {}
+}
+
+function pickEnvironment(v: unknown): Environment | undefined {
+  if (typeof v === 'string' && (ENVIRONMENTS as readonly string[]).includes(v)) {
+    return v as Environment
+  }
+  return undefined
+}
+
+function pickLogLevel(v: unknown): LogLevel | undefined {
+  if (typeof v === 'string') {
+    const upper = v.toUpperCase()
+    if ((LOG_LEVELS as readonly string[]).includes(upper)) return upper as LogLevel
+  }
+  return undefined
+}
+
+function pickString(v: unknown): string | undefined {
+  return typeof v === 'string' ? v : undefined
+}
+
+function pickBoolean(v: unknown): boolean | undefined {
+  if (typeof v === 'boolean') return v
+  if (typeof v === 'string') return parseBoolean(v)
+  return undefined
+}
+
+function pickDatabase(v: unknown): Partial<ConnectionConfig> | undefined {
+  if (!v || typeof v !== 'object') return undefined
+  const src = v as Record<string, unknown>
+  const out: Partial<ConnectionConfig> = {}
+
+  if (typeof src.host === 'string') out.host = src.host
+  if (typeof src.port === 'string') out.port = src.port
+  else if (typeof src.port === 'number') out.port = String(src.port)
+  if (typeof src.namespace === 'string') out.namespace = src.namespace
+  if (typeof src.database === 'string') out.database = src.database
+  if (typeof src.username === 'string') out.username = src.username
+  if (typeof src.password === 'string') out.password = src.password
+  if (typeof src.path === 'string') out.path = src.path
+  if (typeof src.useSSL === 'boolean') out.useSSL = src.useSSL
+  else if (typeof src.useSSL === 'string') {
+    const b = parseBoolean(src.useSSL)
+    if (b !== undefined) out.useSSL = b
+  }
+  if (typeof src.protocol === 'string') {
+    out.protocol = src.protocol as ConnectionConfig['protocol']
+  }
+
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
+/**
+ * Merge a single source into the accumulator, preferring existing
+ * (higher-priority) values. Database sub-fields are merged field-wise
+ * rather than replaced whole-cloth.
+ */
+function mergeSource(accum: SettingsOverrides, source: RawSource): SettingsOverrides {
+  const merged: SettingsOverrides = { ...accum }
+
+  if (merged.environment === undefined) {
+    const v = pickEnvironment(source.environment)
+    if (v !== undefined) merged.environment = v
+  }
+  if (merged.debug === undefined) {
+    const v = pickBoolean(source.debug)
+    if (v !== undefined) merged.debug = v
+  }
+  if (merged.logLevel === undefined) {
+    const v = pickLogLevel(source.logLevel ?? source.log_level)
+    if (v !== undefined) merged.logLevel = v
+  }
+  if (merged.appName === undefined) {
+    const v = pickString(source.appName ?? source.app_name)
+    if (v !== undefined) merged.appName = v
+  }
+  if (merged.version === undefined) {
+    const v = pickString(source.version)
+    if (v !== undefined) merged.version = v
+  }
+  if (merged.migrationPath === undefined) {
+    const v = pickString(source.migrationPath ?? source.migration_path)
+    if (v !== undefined) merged.migrationPath = v
+  }
+
+  const dbSource = pickDatabase(source.database)
+  if (dbSource) {
+    merged.database = { ...dbSource, ...(merged.database ?? {}) }
+  }
+
+  return merged
+}
+
+/**
+ * Fold an override stack down to a fully-resolved {@link Settings} by
+ * filling any remaining holes with {@link DEFAULTS}.
+ */
+function finalise(overrides: SettingsOverrides): Settings {
+  return {
+    environment: overrides.environment ?? DEFAULTS.environment,
+    debug: overrides.debug ?? DEFAULTS.debug,
+    logLevel: overrides.logLevel ?? DEFAULTS.logLevel,
+    appName: overrides.appName ?? DEFAULTS.appName,
+    version: overrides.version ?? DEFAULTS.version,
+    migrationPath: overrides.migrationPath ?? DEFAULTS.migrationPath,
+    database: {
+      ...DEFAULTS.database,
+      ...(overrides.database ?? {}),
+    },
+  }
+}
+
+/**
+ * Normalise an `SettingsOverrides` object passed by the caller into a
+ * `RawSource`, so the explicit layer merges through the same
+ * predicate-based pipeline as env / .env / file.
+ */
+function overridesAsSource(o: SettingsOverrides | undefined): RawSource {
+  if (!o) return {}
+  const out: RawSource = { ...o }
+  if (o.database) out.database = o.database
+  return out
+}
+
+/**
+ * Options accepted by {@link loadSettings}.
+ */
+export interface LoadSettingsOptions extends SettingsOverrides {
+  /**
+   * Directory used to resolve `.env` and `surql.yaml` / `surql.toml`.
+   * Defaults to `Deno.cwd()`.
+   */
+  cwd?: string
+}
+
+/**
+ * Load and resolve surql settings.
+ *
+ * Sources are merged in the following priority order (first wins):
+ *
+ * 1. Explicit fields on `opts`
+ * 2. `SURQL_*` environment variables
+ * 3. `.env` file in `opts.cwd ?? Deno.cwd()`
+ * 4. `surql.yaml` / `surql.yml` / `surql.toml` in `opts.cwd ?? Deno.cwd()`
+ * 5. Built-in defaults
+ *
+ * Requires `--allow-env` for env reads and `--allow-read` for file reads.
+ *
+ * @example
+ * ```ts
+ * const settings = await loadSettings({ environment: 'production' })
+ * ```
+ */
+export async function loadSettings(opts: LoadSettingsOptions = {}): Promise<Settings> {
+  const { cwd, ...overrides } = opts
+  const root = cwd ?? Deno.cwd()
+
+  let stack: SettingsOverrides = {}
+  stack = mergeSource(stack, overridesAsSource(overrides))
+  stack = mergeSource(stack, collectEnv())
+  stack = mergeSource(stack, await collectDotenv(root))
+  stack = mergeSource(stack, await collectFileConfig(root))
+
+  return finalise(stack)
+}
+
+let _cached: Settings | undefined
+let _cachedPromise: Promise<Settings> | undefined
+
+/**
+ * Return a lazily-initialised {@link Settings} instance.
+ *
+ * The first call resolves from all sources using {@link loadSettings}
+ * with no explicit overrides. Subsequent calls return the cached value
+ * synchronously. Use {@link clearSettingsCache} in tests to force a
+ * reload.
+ */
+export async function getSettings(): Promise<Settings> {
+  if (_cached) return _cached
+  if (!_cachedPromise) {
+    _cachedPromise = loadSettings().then((s) => {
+      _cached = s
+      return s
+    })
+  }
+  return _cachedPromise
+}
+
+/**
+ * Clear the {@link getSettings} / {@link getDbConfig} / {@link getMigrationPath}
+ * cache. Primarily intended for use in tests.
+ */
+export function clearSettingsCache(): void {
+  _cached = undefined
+  _cachedPromise = undefined
+}
+
+/**
+ * Convenience accessor for the resolved database configuration.
+ */
+export async function getDbConfig(): Promise<ConnectionConfig> {
+  const settings = await getSettings()
+  return settings.database
+}
+
+/**
+ * Convenience accessor for the resolved migrations directory.
+ */
+export async function getMigrationPath(): Promise<string> {
+  const settings = await getSettings()
+  return settings.migrationPath
+}

--- a/src/test/graph_query.test.ts
+++ b/src/test/graph_query.test.ts
@@ -1,0 +1,115 @@
+import { assertEquals, assertThrows } from '@std/assert'
+import { describe, it } from '@std/testing/bdd'
+import { GraphQuery, GraphQueryError } from '../query/graphQuery.ts'
+
+describe('GraphQuery', () => {
+  describe('toSurql', () => {
+    it('emits basic outgoing traversal', () => {
+      const { sql, vars } = new GraphQuery('user:alice').out('follows').toSurql()
+      assertEquals(sql, 'SELECT * FROM user:alice->follows')
+      assertEquals(vars, {})
+    })
+
+    it('emits incoming edge', () => {
+      const { sql } = new GraphQuery('user:alice').in_('follows').toSurql()
+      assertEquals(sql, 'SELECT * FROM user:alice<-follows')
+    })
+
+    it('emits bidirectional edge', () => {
+      const { sql } = new GraphQuery('user:alice').both('knows').toSurql()
+      assertEquals(sql, 'SELECT * FROM user:alice<->knows')
+    })
+
+    it('chains multiple hops in order', () => {
+      const { sql } = new GraphQuery('user:alice')
+        .out('follows')
+        .out('follows')
+        .toSurql()
+      assertEquals(sql, 'SELECT * FROM user:alice->follows->follows')
+    })
+
+    it('expands depth into repeated v3-valid edge steps', () => {
+      const { sql } = new GraphQuery('user:alice').out('follows', 2).toSurql()
+      // Two hops => two `->follows->?` steps
+      assertEquals(sql, 'SELECT * FROM user:alice->follows->?->follows->?')
+    })
+
+    it('expands incoming depth likewise', () => {
+      const { sql } = new GraphQuery('user:alice').in_('follows', 3).toSurql()
+      assertEquals(sql, 'SELECT * FROM user:alice<-follows<-?<-follows<-?<-follows<-?')
+    })
+
+    it('targets a specific table', () => {
+      const { sql } = new GraphQuery('user:alice').out('likes').to('post').toSurql()
+      assertEquals(sql, 'SELECT * FROM user:alice->likes->post')
+    })
+
+    it('ANDs multiple where conditions', () => {
+      const { sql } = new GraphQuery('user:alice')
+        .out('follows')
+        .where('age > 18')
+        .where('id != user:alice')
+        .toSurql()
+      assertEquals(
+        sql,
+        'SELECT * FROM user:alice->follows WHERE (age > 18) AND (id != user:alice)',
+      )
+    })
+
+    it('selects specified fields', () => {
+      const { sql } = new GraphQuery('user:alice').out('follows').select('id', 'name').toSurql()
+      assertEquals(sql, 'SELECT id, name FROM user:alice->follows')
+    })
+
+    it('renders limit', () => {
+      const { sql } = new GraphQuery('user:alice').out('follows').limit(50).toSurql()
+      assertEquals(sql, 'SELECT * FROM user:alice->follows LIMIT 50')
+    })
+
+    it('renders fetch refs', () => {
+      const { sql } = new GraphQuery('user:alice').out('follows').fetch('author', 'tags').toSurql()
+      assertEquals(sql, 'SELECT * FROM user:alice->follows FETCH author, tags')
+    })
+
+    it('renders all clauses together in canonical order', () => {
+      const { sql } = new GraphQuery('user:alice')
+        .out('likes')
+        .to('post')
+        .where('published = true')
+        .select('id', 'title')
+        .fetch('author')
+        .limit(10)
+        .toSurql()
+      assertEquals(
+        sql,
+        'SELECT id, title FROM user:alice->likes->post WHERE (published = true) FETCH author LIMIT 10',
+      )
+    })
+  })
+
+  describe('validation', () => {
+    it('throws when no traversal step is configured', () => {
+      assertThrows(
+        () => new GraphQuery('user:alice').toSurql(),
+        GraphQueryError,
+        'at least one traversal step',
+      )
+    })
+
+    it('throws when start is empty', () => {
+      assertThrows(() => new GraphQuery(''), GraphQueryError)
+    })
+
+    it('throws on negative limit', () => {
+      assertThrows(() => new GraphQuery('user:alice').out('follows').limit(-1), GraphQueryError)
+    })
+
+    it('throws on zero depth', () => {
+      assertThrows(() => new GraphQuery('user:alice').out('follows', 0), GraphQueryError)
+    })
+
+    it('throws on non-integer depth', () => {
+      assertThrows(() => new GraphQuery('user:alice').out('follows', 1.5), GraphQueryError)
+    })
+  })
+})

--- a/src/test/migration_hooks.test.ts
+++ b/src/test/migration_hooks.test.ts
@@ -1,0 +1,155 @@
+import { assertEquals, assertStringIncludes } from '@std/assert'
+import { describe, it } from '@std/testing/bdd'
+import {
+  checkSchemaDrift,
+  defaultSchemaFilter,
+  generatePrecommitConfig,
+  getStagedSchemaFiles,
+} from '../migration/hooks.ts'
+import { createSnapshot, serializeSnapshot } from '../migration/versioning.ts'
+import { tableSchema } from '../schema/table.ts'
+
+async function withTempDir(test: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: 'surql_hooks_test_' })
+  try {
+    await test(dir)
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {})
+  }
+}
+
+async function writeSnapshot(path: string, tableNames: string[]): Promise<void> {
+  const snapshot = createSnapshot(
+    '20260101000000',
+    tableNames.map((n) => tableSchema(n)),
+    [],
+  )
+  await Deno.writeTextFile(path, serializeSnapshot(snapshot))
+}
+
+describe('Migration hooks', () => {
+  describe('defaultSchemaFilter', () => {
+    it('keeps .surql files at the top level', () => {
+      assertEquals(defaultSchemaFilter('schemas/user.surql'), true)
+    })
+
+    it('excludes files under migrations/', () => {
+      assertEquals(defaultSchemaFilter('db/migrations/20260101120000_create_user.surql'), false)
+    })
+
+    it('excludes non-surql files', () => {
+      assertEquals(defaultSchemaFilter('schemas/user.ts'), false)
+    })
+
+    it('excludes hidden files', () => {
+      assertEquals(defaultSchemaFilter('schemas/.hidden.surql'), false)
+    })
+
+    it('excludes empty paths', () => {
+      assertEquals(defaultSchemaFilter(''), false)
+    })
+  })
+
+  describe('checkSchemaDrift', () => {
+    it('passes when snapshot matches declared tables', async () => {
+      await withTempDir(async (root) => {
+        const schemaDir = `${root}/schemas`
+        await Deno.mkdir(schemaDir, { recursive: true })
+        await Deno.writeTextFile(`${schemaDir}/user.surql`, 'DEFINE TABLE user SCHEMAFULL;')
+
+        const snapshotPath = `${root}/snapshot.json`
+        await writeSnapshot(snapshotPath, ['user'])
+
+        const report = await checkSchemaDrift(snapshotPath, schemaDir)
+        assertEquals(report.passed, true)
+        assertEquals(report.issues.length, 0)
+      })
+    })
+
+    it('flags tables present in code but not in snapshot', async () => {
+      await withTempDir(async (root) => {
+        const schemaDir = `${root}/schemas`
+        await Deno.mkdir(schemaDir, { recursive: true })
+        await Deno.writeTextFile(
+          `${schemaDir}/new.surql`,
+          'DEFINE TABLE user SCHEMAFULL;\nDEFINE TABLE post SCHEMAFULL;',
+        )
+
+        const snapshotPath = `${root}/snapshot.json`
+        await writeSnapshot(snapshotPath, ['user'])
+
+        const report = await checkSchemaDrift(snapshotPath, schemaDir)
+        assertEquals(report.passed, false)
+        assertEquals(report.issues.length, 1)
+        assertEquals(report.issues[0].objectName, 'post')
+        assertEquals(report.issues[0].severity, 'error')
+      })
+    })
+
+    it('flags tables present in snapshot but missing from code', async () => {
+      await withTempDir(async (root) => {
+        const schemaDir = `${root}/schemas`
+        await Deno.mkdir(schemaDir, { recursive: true })
+        await Deno.writeTextFile(`${schemaDir}/user.surql`, 'DEFINE TABLE user SCHEMAFULL;')
+
+        const snapshotPath = `${root}/snapshot.json`
+        await writeSnapshot(snapshotPath, ['user', 'post'])
+
+        const report = await checkSchemaDrift(snapshotPath, schemaDir)
+        assertEquals(report.passed, false)
+        assertEquals(report.issues.some((i) => i.objectName === 'post'), true)
+      })
+    })
+
+    it('passes with a missing snapshot file', async () => {
+      await withTempDir(async (root) => {
+        const schemaDir = `${root}/schemas`
+        await Deno.mkdir(schemaDir, { recursive: true })
+        const report = await checkSchemaDrift(`${root}/none.json`, schemaDir)
+        assertEquals(report.passed, true)
+        assertEquals(report.issues.length, 0)
+      })
+    })
+
+    it('downgrades to warning severity when nonBlocking is set', async () => {
+      await withTempDir(async (root) => {
+        const schemaDir = `${root}/schemas`
+        await Deno.mkdir(schemaDir, { recursive: true })
+        await Deno.writeTextFile(`${schemaDir}/x.surql`, 'DEFINE TABLE extra SCHEMAFULL;')
+
+        const snapshotPath = `${root}/snapshot.json`
+        await writeSnapshot(snapshotPath, [])
+
+        const report = await checkSchemaDrift(snapshotPath, schemaDir, { nonBlocking: true })
+        assertEquals(report.passed, true)
+        assertEquals(report.issues.length, 1)
+        assertEquals(report.issues[0].severity, 'warning')
+      })
+    })
+  })
+
+  describe('generatePrecommitConfig', () => {
+    it('produces a yaml snippet referencing the schema dir', () => {
+      const cfg = generatePrecommitConfig('db/schema')
+      assertStringIncludes(cfg, 'repos:')
+      assertStringIncludes(cfg, 'id: surql-schema-drift')
+      assertStringIncludes(cfg, 'db/schema')
+    })
+
+    it('respects snapshot path override', () => {
+      const cfg = generatePrecommitConfig('db/schema', { snapshotPath: 'custom/snap.json' })
+      assertStringIncludes(cfg, 'custom/snap.json')
+    })
+  })
+
+  describe('getStagedSchemaFiles', () => {
+    it('returns [] when git is not a repo', async () => {
+      await withTempDir(async (root) => {
+        const files = await getStagedSchemaFiles(root)
+        assertEquals(Array.isArray(files), true)
+        // Not a git repo => git exits non-zero => empty list
+        assertEquals(files.length, 0)
+      })
+    })
+  })
+})

--- a/src/test/migration_squash.test.ts
+++ b/src/test/migration_squash.test.ts
@@ -1,0 +1,138 @@
+import { assertEquals, assertRejects, assertStringIncludes } from '@std/assert'
+import { describe, it } from '@std/testing/bdd'
+import { SquashError, squashMigrations } from '../migration/squash.ts'
+
+async function withTempDir(test: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: 'surql_squash_test_' })
+  try {
+    await test(dir)
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {})
+  }
+}
+
+async function writeMigration(dir: string, version: string, slug: string, up: string, down = ''): Promise<void> {
+  const content = ['-- UP', up, '', '-- DOWN', down, ''].join('\n')
+  await Deno.writeTextFile(`${dir}/${version}_${slug}.surql`, content)
+}
+
+describe('Migration squash', () => {
+  it('merges two consecutive migrations', async () => {
+    await withTempDir(async (dir) => {
+      await writeMigration(
+        dir,
+        '20260101120000',
+        'create_user',
+        'DEFINE TABLE user SCHEMAFULL;',
+        'REMOVE TABLE user;',
+      )
+      await writeMigration(
+        dir,
+        '20260101130000',
+        'add_email',
+        'DEFINE FIELD email ON TABLE user TYPE string;',
+        'REMOVE FIELD email ON TABLE user;',
+      )
+
+      const result = await squashMigrations(dir)
+      assertEquals(result.originalCount, 2)
+      assertEquals(result.statementCount, 2)
+      assertEquals(result.originalVersions, ['20260101120000', '20260101130000'])
+      assertStringIncludes(result.content, 'DEFINE TABLE user SCHEMAFULL;')
+      assertStringIncludes(result.content, 'DEFINE FIELD email ON TABLE user TYPE string;')
+      assertStringIncludes(result.content, '-- @squashed-from: 20260101120000..20260101130000')
+      assertStringIncludes(result.content, '-- @checksum: sha256:')
+    })
+  })
+
+  it('merges DOWN statements in reverse order', async () => {
+    await withTempDir(async (dir) => {
+      await writeMigration(dir, '20260101120000', 'a', 'DEFINE TABLE a;', 'REMOVE TABLE a;')
+      await writeMigration(dir, '20260101130000', 'b', 'DEFINE TABLE b;', 'REMOVE TABLE b;')
+
+      const result = await squashMigrations(dir)
+      // The DOWN section should list REMOVE TABLE b; before REMOVE TABLE a;
+      const downSection = result.content.split('-- DOWN')[1]
+      const bIdx = downSection.indexOf('REMOVE TABLE b')
+      const aIdx = downSection.indexOf('REMOVE TABLE a')
+      assertEquals(bIdx >= 0, true)
+      assertEquals(aIdx >= 0, true)
+      assertEquals(bIdx < aIdx, true)
+    })
+  })
+
+  it('respects fromVersion / toVersion bounds', async () => {
+    await withTempDir(async (dir) => {
+      await writeMigration(dir, '20260101110000', 'first', 'DEFINE TABLE a;')
+      await writeMigration(dir, '20260101120000', 'second', 'DEFINE TABLE b;')
+      await writeMigration(dir, '20260101130000', 'third', 'DEFINE TABLE c;')
+      await writeMigration(dir, '20260101140000', 'fourth', 'DEFINE TABLE d;')
+
+      const result = await squashMigrations(dir, '20260101120000', '20260101130000')
+      assertEquals(result.originalCount, 2)
+      assertEquals(result.originalVersions, ['20260101120000', '20260101130000'])
+    })
+  })
+
+  it('stamps a fresh YYYYMMDDHHMMSS version', async () => {
+    await withTempDir(async (dir) => {
+      await writeMigration(dir, '20260101120000', 'a', 'DEFINE TABLE a;')
+      await writeMigration(dir, '20260101130000', 'b', 'DEFINE TABLE b;')
+      const result = await squashMigrations(dir)
+      assertEquals(/^\d{14}$/.test(result.version), true)
+    })
+  })
+
+  it('produces deterministic checksum for identical inputs', async () => {
+    let r1Cs = ''
+    let r2Cs = ''
+    await withTempDir(async (dir) => {
+      await writeMigration(dir, '20260101120000', 'a', 'DEFINE TABLE a;')
+      await writeMigration(dir, '20260101130000', 'b', 'DEFINE TABLE b;')
+      const r1 = await squashMigrations(dir, undefined, undefined, { dryRun: true })
+      r1Cs = r1.checksum
+    })
+    await withTempDir(async (dir) => {
+      await writeMigration(dir, '20260101120000', 'a', 'DEFINE TABLE a;')
+      await writeMigration(dir, '20260101130000', 'b', 'DEFINE TABLE b;')
+      const r2 = await squashMigrations(dir, undefined, undefined, { dryRun: true })
+      r2Cs = r2.checksum
+    })
+    assertEquals(r1Cs, r2Cs)
+  })
+
+  it('dryRun does not write a file', async () => {
+    await withTempDir(async (dir) => {
+      await writeMigration(dir, '20260101120000', 'a', 'DEFINE TABLE a;')
+      await writeMigration(dir, '20260101130000', 'b', 'DEFINE TABLE b;')
+      const result = await squashMigrations(dir, undefined, undefined, { dryRun: true })
+      await assertRejects(
+        () => Deno.stat(result.squashedPath),
+        Deno.errors.NotFound,
+      )
+    })
+  })
+
+  it('writes the squashed file to disk by default', async () => {
+    await withTempDir(async (dir) => {
+      await writeMigration(dir, '20260101120000', 'a', 'DEFINE TABLE a;')
+      await writeMigration(dir, '20260101130000', 'b', 'DEFINE TABLE b;')
+      const result = await squashMigrations(dir)
+      const stat = await Deno.stat(result.squashedPath)
+      assertEquals(stat.isFile, true)
+    })
+  })
+
+  it('rejects when fewer than 2 migrations match', async () => {
+    await withTempDir(async (dir) => {
+      await writeMigration(dir, '20260101120000', 'solo', 'DEFINE TABLE a;')
+      await assertRejects(() => squashMigrations(dir), SquashError)
+    })
+  })
+
+  it('rejects empty directories', async () => {
+    await withTempDir(async (dir) => {
+      await assertRejects(() => squashMigrations(dir), SquashError)
+    })
+  })
+})

--- a/src/test/migration_watcher.test.ts
+++ b/src/test/migration_watcher.test.ts
@@ -1,0 +1,147 @@
+import { assertEquals } from '@std/assert'
+import { describe, it } from '@std/testing/bdd'
+import { watchSchema } from '../migration/watcher.ts'
+import { createSnapshot, serializeSnapshot } from '../migration/versioning.ts'
+import { tableSchema } from '../schema/table.ts'
+import type { DriftReport } from '../migration/hooks.ts'
+
+async function withTempDir(test: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: 'surql_watcher_test_' })
+  try {
+    await test(dir)
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {})
+  }
+}
+
+async function writeSnapshot(path: string, tableNames: string[]): Promise<void> {
+  const snapshot = createSnapshot(
+    '20260101000000',
+    tableNames.map((n) => tableSchema(n)),
+    [],
+  )
+  await Deno.writeTextFile(path, serializeSnapshot(snapshot))
+}
+
+function waitForReport(received: DriftReport[], timeoutMs = 3000): Promise<DriftReport | undefined> {
+  return new Promise((resolve) => {
+    const start = Date.now()
+    const poll = () => {
+      if (received.length > 0) return resolve(received[0])
+      if (Date.now() - start >= timeoutMs) return resolve(undefined)
+      setTimeout(poll, 25)
+    }
+    poll()
+  })
+}
+
+describe('Schema watcher', () => {
+  it('debounces events and invokes callback with a DriftReport', async () => {
+    await withTempDir(async (root) => {
+      const schemaDir = `${root}/schemas`
+      await Deno.mkdir(schemaDir, { recursive: true })
+      const snapshotPath = `${root}/snapshot.json`
+      await writeSnapshot(snapshotPath, ['user'])
+
+      const received: DriftReport[] = []
+      const handle = await watchSchema(
+        schemaDir,
+        (report) => {
+          received.push(report)
+        },
+        { snapshotPath, debounceMs: 100 },
+      )
+
+      try {
+        // Give the watcher a tick to spin up its iterator.
+        await new Promise((r) => setTimeout(r, 50))
+
+        // Rapid writes within the debounce window should coalesce.
+        await Deno.writeTextFile(`${schemaDir}/user.surql`, 'DEFINE TABLE user SCHEMAFULL;')
+        await Deno.writeTextFile(`${schemaDir}/user.surql`, 'DEFINE TABLE user SCHEMAFULL;\n')
+
+        const report = await waitForReport(received)
+        assertEquals(report !== undefined, true)
+        assertEquals(report!.passed, true)
+      } finally {
+        await handle.stop()
+      }
+    })
+  })
+
+  it('reports drift when a new table is introduced', async () => {
+    await withTempDir(async (root) => {
+      const schemaDir = `${root}/schemas`
+      await Deno.mkdir(schemaDir, { recursive: true })
+      const snapshotPath = `${root}/snapshot.json`
+      await writeSnapshot(snapshotPath, ['user'])
+
+      const received: DriftReport[] = []
+      const handle = await watchSchema(
+        schemaDir,
+        (report) => {
+          received.push(report)
+        },
+        { snapshotPath, debounceMs: 80 },
+      )
+
+      try {
+        await new Promise((r) => setTimeout(r, 50))
+        await Deno.writeTextFile(
+          `${schemaDir}/extra.surql`,
+          'DEFINE TABLE extra SCHEMAFULL;',
+        )
+
+        const report = await waitForReport(received)
+        assertEquals(report !== undefined, true)
+        assertEquals(report!.passed, false)
+        assertEquals(report!.issues.some((i) => i.objectName === 'extra'), true)
+      } finally {
+        await handle.stop()
+      }
+    })
+  })
+
+  it('stop() halts future callbacks', async () => {
+    await withTempDir(async (root) => {
+      const schemaDir = `${root}/schemas`
+      await Deno.mkdir(schemaDir, { recursive: true })
+      const snapshotPath = `${root}/snapshot.json`
+      await writeSnapshot(snapshotPath, [])
+
+      const received: DriftReport[] = []
+      const handle = await watchSchema(
+        schemaDir,
+        (report) => {
+          received.push(report)
+        },
+        { snapshotPath, debounceMs: 50 },
+      )
+
+      await handle.stop()
+      assertEquals(handle.stopped, true)
+
+      await Deno.writeTextFile(`${schemaDir}/x.surql`, 'DEFINE TABLE x;')
+      await new Promise((r) => setTimeout(r, 150))
+      assertEquals(received.length, 0)
+    })
+  })
+
+  it('supports AsyncDisposable via Symbol.asyncDispose', async () => {
+    await withTempDir(async (root) => {
+      const schemaDir = `${root}/schemas`
+      await Deno.mkdir(schemaDir, { recursive: true })
+      const snapshotPath = `${root}/snapshot.json`
+      await writeSnapshot(snapshotPath, [])
+
+      const handle = await watchSchema(
+        schemaDir,
+        () => {},
+        { snapshotPath, debounceMs: 50 },
+      )
+
+      await handle[Symbol.asyncDispose]()
+      assertEquals(handle.stopped, true)
+    })
+  })
+})

--- a/src/test/settings.test.ts
+++ b/src/test/settings.test.ts
@@ -1,0 +1,209 @@
+import { assertEquals } from '@std/assert'
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd'
+import { clearSettingsCache, getDbConfig, getMigrationPath, getSettings, loadSettings } from '../settings.ts'
+
+async function withTempDir(test: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: 'surql_settings_test_' })
+  try {
+    await test(dir)
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {})
+  }
+}
+
+type Snapshot = { key: string; value: string | undefined }
+
+function captureEnv(keys: string[]): Snapshot[] {
+  return keys.map((k) => ({ key: k, value: Deno.env.get(k) }))
+}
+
+function restoreEnv(snap: Snapshot[]): void {
+  for (const { key, value } of snap) {
+    if (value === undefined) Deno.env.delete(key)
+    else Deno.env.set(key, value)
+  }
+}
+
+const SURQL_KEYS = [
+  'SURQL_ENVIRONMENT',
+  'SURQL_DEBUG',
+  'SURQL_LOG_LEVEL',
+  'SURQL_APP_NAME',
+  'SURQL_VERSION',
+  'SURQL_MIGRATION_PATH',
+  'SURQL_HOST',
+  'SURQL_PORT',
+  'SURQL_NAMESPACE',
+  'SURQL_DATABASE',
+  'SURQL_USERNAME',
+  'SURQL_PASSWORD',
+]
+
+describe('Settings loader', () => {
+  let snapshot: Snapshot[] = []
+
+  beforeEach(() => {
+    snapshot = captureEnv(SURQL_KEYS)
+    for (const { key } of snapshot) Deno.env.delete(key)
+    clearSettingsCache()
+  })
+
+  afterEach(() => {
+    restoreEnv(snapshot)
+    clearSettingsCache()
+  })
+
+  it('returns defaults when no source is configured', async () => {
+    await withTempDir(async (cwd) => {
+      const s = await loadSettings({ cwd })
+      assertEquals(s.environment, 'development')
+      assertEquals(s.debug, true)
+      assertEquals(s.logLevel, 'INFO')
+      assertEquals(s.appName, 'surql')
+      assertEquals(s.migrationPath, 'migrations')
+      assertEquals(s.database.host, '127.0.0.1')
+      assertEquals(s.database.port, '8000')
+    })
+  })
+
+  it('reads SURQL_* env vars', async () => {
+    await withTempDir(async (cwd) => {
+      Deno.env.set('SURQL_ENVIRONMENT', 'production')
+      Deno.env.set('SURQL_DEBUG', 'false')
+      Deno.env.set('SURQL_LOG_LEVEL', 'WARNING')
+      Deno.env.set('SURQL_APP_NAME', 'app')
+      Deno.env.set('SURQL_HOST', 'db.example.com')
+      Deno.env.set('SURQL_PORT', '9000')
+
+      const s = await loadSettings({ cwd })
+      assertEquals(s.environment, 'production')
+      assertEquals(s.debug, false)
+      assertEquals(s.logLevel, 'WARNING')
+      assertEquals(s.appName, 'app')
+      assertEquals(s.database.host, 'db.example.com')
+      assertEquals(s.database.port, '9000')
+    })
+  })
+
+  it('reads .env file values', async () => {
+    await withTempDir(async (cwd) => {
+      const env = [
+        'SURQL_ENVIRONMENT=staging',
+        'SURQL_MIGRATION_PATH=db/migrations',
+        'SURQL_HOST="quoted.example"',
+        "SURQL_NAMESPACE='nsquoted'",
+        '# commented=ignored',
+        'UNRELATED=skip',
+      ].join('\n')
+      await Deno.writeTextFile(`${cwd}/.env`, env)
+
+      const s = await loadSettings({ cwd })
+      assertEquals(s.environment, 'staging')
+      assertEquals(s.migrationPath, 'db/migrations')
+      assertEquals(s.database.host, 'quoted.example')
+      assertEquals(s.database.namespace, 'nsquoted')
+    })
+  })
+
+  it('reads surql.yaml file values', async () => {
+    await withTempDir(async (cwd) => {
+      const yaml = [
+        'environment: staging',
+        'debug: false',
+        'migrationPath: db/migrations',
+        'database:',
+        '  host: yaml.example',
+        '  port: "9100"',
+        '  namespace: yamlns',
+      ].join('\n')
+      await Deno.writeTextFile(`${cwd}/surql.yaml`, yaml)
+
+      const s = await loadSettings({ cwd })
+      assertEquals(s.environment, 'staging')
+      assertEquals(s.debug, false)
+      assertEquals(s.migrationPath, 'db/migrations')
+      assertEquals(s.database.host, 'yaml.example')
+      assertEquals(s.database.port, '9100')
+      assertEquals(s.database.namespace, 'yamlns')
+    })
+  })
+
+  it('reads surql.toml file values', async () => {
+    await withTempDir(async (cwd) => {
+      const toml = [
+        'environment = "production"',
+        'appName = "from-toml"',
+        '',
+        '[database]',
+        'host = "toml.example"',
+        'port = "9200"',
+        'namespace = "tomlns"',
+      ].join('\n')
+      await Deno.writeTextFile(`${cwd}/surql.toml`, toml)
+
+      const s = await loadSettings({ cwd })
+      assertEquals(s.environment, 'production')
+      assertEquals(s.appName, 'from-toml')
+      assertEquals(s.database.host, 'toml.example')
+      assertEquals(s.database.port, '9200')
+      assertEquals(s.database.namespace, 'tomlns')
+    })
+  })
+
+  it('resolves priority: explicit > env > .env > file', async () => {
+    await withTempDir(async (cwd) => {
+      await Deno.writeTextFile(`${cwd}/surql.yaml`, 'environment: production\nappName: fromYaml\n')
+      await Deno.writeTextFile(`${cwd}/.env`, 'SURQL_ENVIRONMENT=staging\nSURQL_APP_NAME=fromDotenv\n')
+      Deno.env.set('SURQL_APP_NAME', 'fromEnv')
+
+      const s = await loadSettings({ cwd, environment: 'development' })
+      // explicit wins on environment
+      assertEquals(s.environment, 'development')
+      // env wins for appName over .env and yaml
+      assertEquals(s.appName, 'fromEnv')
+    })
+  })
+
+  it('parses boolean debug from env variants', async () => {
+    await withTempDir(async (cwd) => {
+      for (
+        const [raw, expected] of [
+          ['true', true],
+          ['1', true],
+          ['yes', true],
+          ['false', false],
+          ['0', false],
+          ['no', false],
+        ] as Array<[string, boolean]>
+      ) {
+        Deno.env.set('SURQL_DEBUG', raw)
+        clearSettingsCache()
+        const s = await loadSettings({ cwd })
+        assertEquals(s.debug, expected, `raw=${raw}`)
+      }
+    })
+  })
+
+  it('getSettings caches the resolved value', async () => {
+    clearSettingsCache()
+    const a = await getSettings()
+    const b = await getSettings()
+    assertEquals(a, b)
+  })
+
+  it('getDbConfig and getMigrationPath read through cache', async () => {
+    clearSettingsCache()
+    const path = await getMigrationPath()
+    const db = await getDbConfig()
+    assertEquals(typeof path, 'string')
+    assertEquals(typeof db.host, 'string')
+  })
+
+  it('ignores unknown SURQL_ keys', async () => {
+    await withTempDir(async (cwd) => {
+      Deno.env.set('SURQL_SOMETHING_UNKNOWN', 'whatever')
+      const s = await loadSettings({ cwd })
+      assertEquals(s.environment, 'development')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes five TS parity gaps against `surql-py` in one branch.

### `src/settings.ts` (543 LOC)
Layered loader: explicit args → `SURQL_*` env → `.env` → project-root `surql.yaml` / `surql.yml` / `surql.toml`. Uses `jsr:@std/yaml` + `jsr:@std/toml`.

### `src/query/graphQuery.ts` (246 LOC)
Fluent builder: `.out` / `.in_` / `.both` / `.to` / `.where` / `.select` / `.limit` / `.fetch` / `.count` / `.exists`. `.toSurql()` returns `{ sql, vars }`. `.execute(client)` dispatcher. Depth > 1 emits repeated `->edge->?` hops (matches rs/go — v3 rejects the py `<depth>` suffix).

### `src/migration/squash.ts` (306 LOC)
Operates on `.surql` files with `-- UP` / `-- DOWN` markers (or falls back to `loadMigration` for TS migrations). Emits a new `.surql` with `-- @squashed-from:` and `-- @checksum: sha256:` headers.

### `src/migration/hooks.ts` (309 LOC)
Git pre-commit drift detection. `checkSchemaDrift`, `generatePrecommitConfig`, `defaultSchemaFilter`, `getStagedSchemaFiles`, plus `DriftIssue` / `DriftReport` / `DriftSeverity` types. Content-based comparison against an on-disk `SchemaSnapshot` JSON (py does mtime compare + dynamic module import — not viable in TS).

### `src/migration/watcher.ts` (166 LOC)
Built-in `Deno.watchFs` + debounced (500 ms default) drift checks. Returns an `AsyncDisposable` so callers can `await using`.

## Deviations from py (documented inline)

- `GraphQuery` depth expansion follows rs/go.
- `settings.ts` reads project-root YAML/TOML instead of `pyproject.toml [tool.surql]`.
- `squash.ts` handles `.surql` + `.ts` migrations.
- `hooks.ts` content-based drift instead of dynamic import + mtime.
- `watcher.ts` uses Deno's native `watchFs` — no chokidar dep.

## Test plan

- [x] `deno fmt --check` clean
- [x] `deno lint` clean
- [x] `deno check mod.ts` clean
- [x] `deno task test` — 323 → 328 passed (+53 new test cases, +57 steps). 6 pre-existing integration failures (require a live SurrealDB) are unchanged.

Refs #12, closes #21.