### PR TITLE
feat(ci): add scheduled audit + dep-review + nightly + PR-title-lint workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+# Dependabot config.
+#
+# Deno / JSR is NOT yet supported by Dependabot as a package ecosystem
+# (no `deno` or `jsr` value for `package-ecosystem`). `npm:` specifiers
+# used via Deno's compatibility layer are declared in `deno.json` and
+# locked in `deno.lock`, neither of which Dependabot can parse. For
+# now, those specifiers are covered by:
+#   - `.github/workflows/audit.yml` (daily npm audit synthesized from
+#     `deno.json`)
+#   - `.github/workflows/nightly.yml` (daily Deno stable + canary run)
+# Revisit once Dependabot adds Deno / JSR support.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '06:00'
+      timezone: 'America/Anchorage'
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,85 @@
+name: Security Audit
+
+# Deno / JSR does not yet ship a first-party `deno audit` comparable to
+# `cargo audit` or `govulncheck`. `@oneiriq/surql` is a pure JSR module
+# that pulls a handful of npm specifiers (`zod`, `surrealdb`) via
+# Deno's `npm:` compatibility layer. To keep parity with surql-rs /
+# surql-go / surql-py, we synthesize a package.json listing just the
+# npm specifiers from `deno.json` and run `npm audit` against it.
+#
+# The synthesized manifest is discarded after the run -- no lockfile
+# is committed. JSR-only updates are still caught by `nightly.yml` via
+# the Deno version matrix.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release/**'
+    paths:
+      - 'deno.json'
+      - 'deno.lock'
+      - '.github/workflows/audit.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'deno.json'
+      - 'deno.lock'
+      - '.github/workflows/audit.yml'
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  audit:
+    name: npm audit (npm: specifiers from deno.json)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Synthesize package.json from deno.json npm: imports
+        run: |
+          node <<'EOF'
+          const fs = require('node:fs')
+          const deno = JSON.parse(fs.readFileSync('deno.json', 'utf8'))
+          const imports = deno.imports ?? {}
+          const deps = {}
+          for (const [_, spec] of Object.entries(imports)) {
+            if (typeof spec !== 'string') continue
+            if (!spec.startsWith('npm:')) continue
+            // strip "npm:", then split "name@range" honoring scoped packages
+            const bare = spec.slice(4)
+            const at = bare.lastIndexOf('@')
+            if (at <= 0) {
+              deps[bare] = '*'
+              continue
+            }
+            const name = bare.slice(0, at)
+            const range = bare.slice(at + 1).split('/')[0]
+            // keep the tightest pin we saw for a given name
+            if (!deps[name] || deps[name] === '*') {
+              deps[name] = range
+            }
+          }
+          const pkg = {
+            name: 'surql-audit-synth',
+            version: '0.0.0',
+            private: true,
+            dependencies: deps
+          }
+          fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2))
+          console.log('Synthesized package.json:')
+          console.log(JSON.stringify(pkg, null, 2))
+          EOF
+
+      - name: Run npm audit
+        run: npm audit --audit-level=moderate --omit=dev

--- a/.github/workflows/dep-review.yml
+++ b/.github/workflows/dep-review.yml
@@ -1,0 +1,27 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  dep-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: moderate
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,82 @@
+name: Nightly
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  # Unit + type checks across the full OS x Deno matrix. macOS runners
+  # don't have Docker pre-installed on GitHub-hosted runners, so the
+  # integration tests (which spin up a SurrealDB container) only run
+  # in the separate integration job below.
+  sanity:
+    name: Sanity (${{ matrix.os }} / Deno ${{ matrix.deno }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        deno: [v2.x, canary]
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: ${{ matrix.deno }}
+
+      - name: Check formatting
+        run: deno fmt --check
+
+      - name: Check lint
+        run: deno lint
+
+      - name: Type check
+        run: deno check mod.ts
+
+      - name: Run unit tests
+        run: |
+          deno test -A \
+            --ignore="src/test/auth.test.ts,src/test/integration.test.ts,src/test/integration_crud.test.ts,src/test/integration_client.test.ts" \
+            -q
+
+  # Integration tests against both the pinned v3 image and `latest`.
+  # Ubuntu only because GitHub-hosted macOS runners lack Docker.
+  integration:
+    name: Integration (Deno ${{ matrix.deno }} / surrealdb:${{ matrix.surreal }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        deno: [v2.x, canary]
+        surreal: ['v3.0.5', 'latest']
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: ${{ matrix.deno }}
+
+      - name: Start SurrealDB (${{ matrix.surreal }})
+        run: |
+          docker run -d \
+            --name surrealdb \
+            -p 8000:8000 \
+            surrealdb/surrealdb:${{ matrix.surreal }} \
+            start --user root --pass root memory
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:8000/health; then
+              echo "SurrealDB is ready"
+              break
+            fi
+            echo "Waiting for SurrealDB... attempt $i"
+            sleep 2
+          done
+
+      - name: Run deno task test
+        run: deno task test

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,42 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  lint-pr-title:
+    name: Conventional Commit PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            revert
+          requireScope: false
+          subjectPattern: ^[A-Za-z].+$
+          subjectPatternError: |
+            The subject "{subject}" found in PR title "{title}" must start with
+            a letter.


### PR DESCRIPTION
## Summary

Mirrors the rs/go/py CI surface onto the TS port.

### `.github/workflows/`
- **`audit.yml`** — PR + daily 04:00 UTC + dispatch. No first-party `deno audit` exists, so synthesize a `package.json` from the `npm:` specifiers in `deno.json` and run `npm audit --audit-level=moderate --omit=dev`. Caveat documented inline.
- **`dep-review.yml`** — `actions/dependency-review-action@v4`, `fail-on-severity: moderate`, `comment-summary-in-pr: on-failure`.
- **`nightly.yml`** — 03:00 UTC + dispatch. Sanity matrix Deno v2.x/canary × ubuntu/macos (fmt + lint + check + unit tests). Integration matrix ubuntu-only (macOS runners lack Docker) × SurrealDB v3.0.5 + latest.
- **`pr-title.yml`** — `amannn/action-semantic-pull-request@v5`; types `feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert`.

### `.github/dependabot.yml`
- Weekly `github-actions`. Deno/JSR not supported by Dependabot yet (documented inline).

## Test plan

- [x] `deno fmt --check` clean (152 files)
- [x] `deno lint` clean (152 files)
- [x] `deno check mod.ts` clean
- [x] Unit tests — 328 passed (same invocation as existing `test.yml`)

Refs #12, closes #23.