### PR TITLE
chore(release): bump version to 1.3.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
 	"lock": true,
 
 	"name": "@oneiriq/surql",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"license": "MIT",
 	"exports": {
 		".": "./mod.ts",


### PR DESCRIPTION
Finalise release/1.3.0 with the real version string. Query-UX parity wave.
Closes #6, #7, #8.