### PR TITLE
docs: refresh site for parity + query-UX + CLI surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,73 @@
 # Changelog
 
+## [1.3.2] - 2026-04-19
+
+### Changed
+
+- **Docs refresh** (#37): documented every wave that landed since v1.0.0. New pages: `docs/v3-patterns.md` (buffered BEGIN/COMMIT, `IF NOT EXISTS` emitter, unrolled graph depth), `docs/query-ux.md` (`typeRecord` / `typeThing`, function factories, `FunctionValueExpression`, `extractMany` / `hasResult`, `aggregateRecords`, `updateRecord` / `getRecord` overloads), `docs/cli.md` (`surql migrate|schema|db|orchestrate|settings` reference), `docs/migration.md` (upgrade notes v1.1.0 → v1.2.0 → v1.3.x). README refreshed with first-class helper examples (`typeRecord`, `timeNow`, `aggregateRecords`, `surql` CLI). mkdocs nav extended; `mkdocs build --strict` stays clean.
+
+### Housekeeping
+
+- Version bumped to `1.3.2` in `deno.json` so the refreshed docs can publish.
+
+---
+
+## [1.3.1] - 2026-04-19
+
+### Fixed
+
+- **CI**: Excluded `src/test/integration*.test.ts` from publish-time unit test jobs so JSR/npm publishes no longer require a live SurrealDB container. Integration tests still run in the dedicated integration workflow.
+
+---
+
+## [1.3.0] - 2026-04-19
+
+### Added — Query-UX wave (#29)
+
+- **`typeRecord(table, id?)` / `typeThing(table, id?)`** (#6): first-class SurrealDB v3 record references. `typeThing` is the parity alias for surql-py/rs/go. Emits `type::record('table:id')` (v3-valid; v3 dropped `type::thing`).
+- **Function factories** (#7): `countIf`, `mathAbs`/`mathCeil`/`mathFloor`/`mathRound`, `stringLen`/`stringLower`/`stringUpper`/`stringConcat`. Short-form aliases (`abs_`, `ceil`, `floor`, `round_`, `upper`, `lower`, `concat`, `stringLength`) retained for pre-1.3.0 callers.
+- **`FunctionValueExpression`** (#7): a dual-purpose expression that implements both `FunctionExpression` and `SurrealFnValue`, so the same factory output renders inline in `SELECT` / `WHERE` **and** in `SET` clauses without a second wrap.
+- **Result extraction aliases** (#8): `extractMany` (parity with surql-py `extract_many`) and `hasResult` (parity with `has_result`) surfaced alongside the existing `extractResult` / `hasResults`.
+- **`aggregateRecords(options)`**: one-shot aggregation helper accepting `{ table, select, groupBy?, groupAll?, where?, orderBy?, limit?, client }` and returning rows keyed by the aliases in `select`. `groupAll` and `groupBy` are mutually exclusive.
+- **`typeRecord`-aware CRUD overloads**: `updateRecord(db, ref, data)` and `getRecord(db, ref)` now accept a `typeRecord(...)` value in place of `(table, id)`. The original signatures remain fully supported.
+
+### Added — Developer experience
+
+- **Pre-push hook** (#30): `.githooks/pre-push` mirrors the CI `fmt --check` / `lint` / `check` gates and guards the push locally. Enable once per clone via `git config core.hooksPath .githooks`. The full `deno task test` suite is opt-in via `SURQL_PRE_PUSH_INTEGRATION=1` (requires a running SurrealDB v3.0.5 container). CONTRIBUTING.md documents the workflow.
+
+---
+
+## [1.2.0] - 2026-04-19
+
+### Added — Parity wave (#19, #21, #24)
+
+- **Structured schema parser** (#19): `parseDbInfo`, `parseTableInfo`, `parseFields`, `parseIndexes`, `parseEvents`, `parseAccess`, `parseEdgeInfo`, plus `SchemaParseError`. Full port of the surql-py/surql-rs/surql-go `DEFINE` parser (HNSW index, JWT URL/duration variants, lookbehind edge cases).
+- **Layered settings loader** (`loadSettings`, `getSettings`, `clearSettingsCache`, `getDbConfig`, `getMigrationPath`): reads env vars, `.env`, `surql.yaml`, and `surql.toml` with precedence matching the py/rs/go ports.
+- **GraphQuery fluent builder** (`GraphQuery`, `GraphQueryError`, `GraphQueryRendered`): chainable graph traversal. **v3 depth handling**: passes a positive `depth` unrolled as repeated `->edge->?` hops (v3 dropped the `->edge2` suffix the py reference emits).
+- **Migration squash** (`squashMigrations`, `SquashError`, `SquashOptions`, `SquashResult`): flatten multiple `.surql` migrations into one while preserving checksums and version ordering.
+- **Schema drift hooks** (`checkSchemaDrift`, `defaultSchemaFilter`, `generatePrecommitConfig`, `getStagedSchemaFiles`, `DriftIssue`, `DriftReport`): git-hook / CI-friendly drift detection against a persisted snapshot.
+- **Schema watcher** (`watchSchema`, `WatchCallback`, `WatchHandle`, `WatchSchemaOptions`): filesystem watcher that re-runs drift checks on change with a configurable debounce.
+- **CLI** (#24): new `surql` binary (`./src/cli/main.ts`, exposed as `"./cli"` export). Subcommands:
+  - `surql migrate up|down|status|history|create|validate|generate|squash`
+  - `surql schema show|diff|generate|sync|export|tables|inspect|validate|check|hook-config|watch|visualize`
+  - `surql db init|ping|info|reset|query|version`
+  - `surql orchestrate deploy|status|validate`
+  - `surql settings` (dump resolved configuration)
+  - Built on `@cliffy/command`; honours `--config <path:string>` at every level.
+
+### Added — SurrealDB v3 correctness (#13, #14, #15)
+
+- **Buffered transactions** (#13): `Transaction.execute()` now queues statements client-side and flushes them as a single `BEGIN TRANSACTION; ...; COMMIT TRANSACTION;` request on `commit()`. SurrealDB v3 rejects bare `COMMIT TRANSACTION` / `CANCEL TRANSACTION` statements across isolated RPCs, so streaming the bookends no longer works.
+- **`IF NOT EXISTS` emitter** (#15): `generateTableSql`, `generateEdgeSql`, `generateAccessSql`, and `generateSchemaSql` accept an `ifNotExists: boolean` option. Set `true` to emit `DEFINE TABLE IF NOT EXISTS`, `DEFINE ACCESS IF NOT EXISTS`, etc., so schemas can be re-applied idempotently against a live v3 database.
+- **Integration CI pinned to SurrealDB v3.0.5** (#14): `.github/workflows/integration.yml` runs against `surrealdb/surrealdb:v3.0.5`; unit tests (publish jobs) exclude `integration*.test.ts`.
+
+### Added — Schema definition extensions
+
+- **HNSW index** (`hnswIndex`, `HnswDistanceType`) on top of the existing MTREE index.
+- **JWT URL + access durations** on `DEFINE ACCESS`.
+
+---
+
 ## [1.1.0] - 2026-03-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,102 +2,148 @@
 
 [![JSR Version](https://img.shields.io/jsr/v/@oneiriq/surql)](https://jsr.io/@oneiriq/surql)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![SurrealDB](https://img.shields.io/badge/SurrealDB-1.0%2B-ff00a0)](https://surrealdb.com/)
+[![SurrealDB](https://img.shields.io/badge/SurrealDB-v3-ff00a0)](https://surrealdb.com/)
 
-A type-safe query builder and client for [SurrealDB](https://surrealdb.com/). Build complex queries, manage connections, and perform typed CRUD all from TypeScript, available for both Deno and Node.js.
+Code-first database toolkit for [SurrealDB](https://surrealdb.com/). Type-safe query builder, schema/migration engine, orchestrator, and `surql` CLI — all from TypeScript, for Deno and Node.js.
 
 ## Features
 
-- **Fluent Query Builder** - Chainable API for SELECT, INSERT, UPDATE, DELETE with full TypeScript generics
-- **Multi-Runtime** - Works with both Deno and Node.js (v18+) via JSR and NPM
-- **Authentication** - Root, Namespace, Database, and Scope-level auth with JWT lifecycle management
-- **Advanced CRUD** - Merge (partial update), JSON Patch (RFC 6902), and Upsert operations
-- **Aggregations** - GROUP BY, HAVING, count/sum/avg/min/max with fluent syntax
-- **Pagination** - limit/offset and page-based pagination
-- **Type Utilities** - `Serialized<T>` and `createSerializer` for mapping raw SurrealDB types
-- **Connection Management** - `SurrealConnectionManager` for pooling and `SurQLClient` for single connections
-- **Input Sanitization** - Built-in injection prevention and rich error types
-- **Zero Dependencies** - Minimal footprint, native Promise-based execution
+- **Fluent Query Builder** — Chainable API for SELECT/INSERT/UPDATE/DELETE with full generics; `typeRecord`, `timeNow`, `mathSum`, `countIf`, `stringLower` and friends render inline in both expression and `SET` contexts.
+- **Code-first Schema + Migrations** — `DEFINE` emitters with `IF NOT EXISTS`, structured schema parser, migration runner, squash, rollback, and drift detection.
+- **SurrealDB v3 correctness** — Buffered `BEGIN ... COMMIT`, unrolled `GraphQuery` depth, v3-valid `type::record()` everywhere.
+- **`surql` CLI** — `migrate`, `schema`, `db`, `orchestrate`, `settings` subcommands (built on `@cliffy/command`).
+- **Multi-runtime** — JSR for Deno, npm for Node.js 18+.
+- **Layered settings** — env + `.env` + `surql.yaml` + `surql.toml` via `loadSettings()`.
+- **Auth & CRUD** — Root/Namespace/Database/Scope sign-in, JSON Patch (RFC 6902), merge, upsert, aggregations, pagination.
+- **Input sanitisation** — Identifier validation, injection prevention, rich error types.
 
-## Quick Start
+## Install
 
-### Deno
+=== "Deno (JSR)"
 
-```typescript
-import { SurQLClient, query } from 'jsr:@oneiriq/surql'
-```
+    ```ts
+    import { SurQLClient, query } from 'jsr:@oneiriq/surql'
+    ```
 
-Or via `deno.json` import map:
+    Or via an import map in `deno.json`:
 
-```json
-{
-  "imports": {
-    "surql": "jsr:@oneiriq/surql"
-  }
-}
-```
+    ```json
+    { "imports": { "surql": "jsr:@oneiriq/surql" } }
+    ```
 
-### Node.js
+=== "Node.js (npm)"
 
-```bash
-npm install @oneiriq/surql
-```
+    ```bash
+    npm install @oneiriq/surql
+    ```
 
-```typescript
-import { SurQLClient, query } from '@oneiriq/surql'
-```
+    ```ts
+    import { SurQLClient, query } from '@oneiriq/surql'
+    ```
 
-### Example
+## Quick Example
 
-```typescript
-import { SurQLClient, RecordId, Serialized, createSerializer } from 'surql'
+```ts
+import {
+  aggregateRecords,
+  count,
+  countIf,
+  createRecord,
+  getRecord,
+  mathSum,
+  SurQLClient,
+  timeNow,
+  typeRecord,
+  updateRecord,
+} from 'jsr:@oneiriq/surql'
 
-interface User {
-  id: RecordId
-  username: string
-  email: string
-  created_at: Date
-}
+const client = new SurQLClient({
+  host: 'localhost',
+  port: '8000',
+  namespace: 'myapp',
+  database: 'prod',
+  username: 'root',
+  password: 'root',
+})
+await client.signin({ type: 'root', username: 'root', password: 'root' })
+const db = await client.getConnection()
 
-type SerializedUser = Serialized<User>
+// First-class record references — render as type::record('task:abc').
+const task = typeRecord('task', 'abc')
 
-const serializer = createSerializer<User>()
-const mapUser = (u: User): SerializedUser => ({
-  id: serializer.id(u),
-  username: u.username,
-  email: u.email,
-  created_at: serializer.date(u.created_at),
+// time::now() / math::sum() render inline in SET clauses.
+await createRecord(db, 'audit', { at: timeNow(), action: 'start' })
+await updateRecord(db, task, { status: 'done', finishedAt: timeNow() })
+
+// typeRecord works for reads too.
+const row = await getRecord<Task>(db, task)
+
+// Typed aggregation — no hand-rolled SurrealQL.
+const buckets = await aggregateRecords({
+  table: 'memory_entry',
+  select: {
+    total: count(),
+    failed: countIf('status = "failed"'),
+    strengthSum: mathSum('strength'),
+  },
+  groupBy: ['network'],
+  client: db,
 })
 
-const client = new SurQLClient(config)
-await client.signin({ type: 'root', username: 'root', password: 'password' })
-
-const users = await client.query<User, SerializedUser>('users')
-  .where({ active: true })
-  .orderBy('username')
-  .limit(10)
-  .map(mapUser)
-  .execute()
+await client.close()
 ```
+
+## `surql` CLI
+
+```bash
+# Run from a clone
+deno task cli --help
+
+# Apply pending migrations
+deno task cli migrate up
+
+# Inspect live schema vs snapshot
+deno task cli schema diff --schema db/snapshot.json
+
+# Orchestrate across environments (JSON config)
+deno task cli orchestrate deploy --environments staging,production --strategy rolling --batch-size 2
+```
+
+The full reference lives at [docs/cli.md](docs/cli.md) (rendered on the docs site).
 
 ## Documentation
 
-See the **[Changelog](./CHANGELOG.md)** for release history.
+- Full docs site: <https://oneiriq.github.io/surql>
+- [Upgrade guide](docs/migration.md) — v1.1.0 → v1.2.0 → v1.3.x
+- [SurrealDB v3 patterns](docs/v3-patterns.md)
+- [Query UX](docs/query-ux.md) — `typeRecord`, function factories, `aggregateRecords`, overloads
+- [CLI](docs/cli.md)
+- [Changelog](CHANGELOG.md)
 
 ## Requirements
 
-- Deno 1.40+ or Node.js 18+
-- SurrealDB 1.0+
+- Deno 2.x or Node.js 18+
+- SurrealDB v3 (integration tests pinned to `surrealdb/surrealdb:v3.0.5`)
+
+## Contributing
+
+Local gating is enforced by `.githooks/pre-push` (mirrors CI). Enable once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## License
 
-MIT - see [LICENSE](LICENSE).
+MIT — see [LICENSE](LICENSE).
 
 ## Python
 
-Looking for SurrealDB tooling in Python? Check out **[surql-py](https://github.com/Oneiriq/surql-py)** the code-first schema, migration, and query toolkit for SurrealDB built for Python 3.12+.
+Looking for SurrealDB tooling in Python? See **[surql-py](https://github.com/Oneiriq/surql-py)** — the code-first schema, migration, and query toolkit for SurrealDB built for Python 3.12+.
 
 ## Support
 
 - Issues: [GitHub Issues](https://github.com/Oneiriq/surql/issues)
-- Changelog: [CHANGELOG](CHANGELOG.md)
+- Changelog: [CHANGELOG.md](CHANGELOG.md)

--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
 	"lock": true,
 
 	"name": "@oneiriq/surql",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"license": "MIT",
 	"exports": {
 		".": "./mod.ts",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,101 @@
 # Changelog
 
+## [1.3.2] - 2026-04-19
+
+### Changed
+
+- **Docs refresh** (#37): documented every wave that landed since v1.0.0. New pages: `docs/v3-patterns.md` (buffered BEGIN/COMMIT, `IF NOT EXISTS` emitter, unrolled graph depth), `docs/query-ux.md` (`typeRecord` / `typeThing`, function factories, `FunctionValueExpression`, `extractMany` / `hasResult`, `aggregateRecords`, `updateRecord` / `getRecord` overloads), `docs/cli.md` (`surql migrate|schema|db|orchestrate|settings` reference), `docs/migration.md` (upgrade notes v1.1.0 → v1.2.0 → v1.3.x). README refreshed with first-class helper examples (`typeRecord`, `timeNow`, `aggregateRecords`, `surql` CLI). mkdocs nav extended; `mkdocs build --strict` stays clean.
+
+### Housekeeping
+
+- Version bumped to `1.3.2` in `deno.json` so the refreshed docs can publish.
+
+---
+
+## [1.3.1] - 2026-04-19
+
+### Fixed
+
+- **CI**: Excluded `src/test/integration*.test.ts` from publish-time unit test jobs so JSR/npm publishes no longer require a live SurrealDB container. Integration tests still run in the dedicated integration workflow.
+
+---
+
+## [1.3.0] - 2026-04-19
+
+### Added — Query-UX wave (#29)
+
+- **`typeRecord(table, id?)` / `typeThing(table, id?)`** (#6): first-class SurrealDB v3 record references. `typeThing` is the parity alias for surql-py/rs/go. Emits `type::record('table:id')` (v3-valid; v3 dropped `type::thing`).
+- **Function factories** (#7): `countIf`, `mathAbs`/`mathCeil`/`mathFloor`/`mathRound`, `stringLen`/`stringLower`/`stringUpper`/`stringConcat`. Short-form aliases (`abs_`, `ceil`, `floor`, `round_`, `upper`, `lower`, `concat`, `stringLength`) retained for pre-1.3.0 callers.
+- **`FunctionValueExpression`** (#7): a dual-purpose expression that implements both `FunctionExpression` and `SurrealFnValue`, so the same factory output renders inline in `SELECT` / `WHERE` **and** in `SET` clauses without a second wrap.
+- **Result extraction aliases** (#8): `extractMany` (parity with surql-py `extract_many`) and `hasResult` (parity with `has_result`) surfaced alongside the existing `extractResult` / `hasResults`.
+- **`aggregateRecords(options)`**: one-shot aggregation helper accepting `{ table, select, groupBy?, groupAll?, where?, orderBy?, limit?, client }` and returning rows keyed by the aliases in `select`. `groupAll` and `groupBy` are mutually exclusive.
+- **`typeRecord`-aware CRUD overloads**: `updateRecord(db, ref, data)` and `getRecord(db, ref)` now accept a `typeRecord(...)` value in place of `(table, id)`. The original signatures remain fully supported.
+
+### Added — Developer experience
+
+- **Pre-push hook** (#30): `.githooks/pre-push` mirrors the CI `fmt --check` / `lint` / `check` gates and guards the push locally. Enable once per clone via `git config core.hooksPath .githooks`. The full `deno task test` suite is opt-in via `SURQL_PRE_PUSH_INTEGRATION=1` (requires a running SurrealDB v3.0.5 container). CONTRIBUTING.md documents the workflow.
+
+---
+
+## [1.2.0] - 2026-04-19
+
+### Added — Parity wave (#19, #21, #24)
+
+- **Structured schema parser** (#19): `parseDbInfo`, `parseTableInfo`, `parseFields`, `parseIndexes`, `parseEvents`, `parseAccess`, `parseEdgeInfo`, plus `SchemaParseError`. Full port of the surql-py/surql-rs/surql-go `DEFINE` parser (HNSW index, JWT URL/duration variants, lookbehind edge cases).
+- **Layered settings loader** (`loadSettings`, `getSettings`, `clearSettingsCache`, `getDbConfig`, `getMigrationPath`): reads env vars, `.env`, `surql.yaml`, and `surql.toml` with precedence matching the py/rs/go ports.
+- **GraphQuery fluent builder** (`GraphQuery`, `GraphQueryError`, `GraphQueryRendered`): chainable graph traversal. **v3 depth handling**: passes a positive `depth` unrolled as repeated `->edge->?` hops (v3 dropped the `->edge2` suffix the py reference emits).
+- **Migration squash** (`squashMigrations`, `SquashError`, `SquashOptions`, `SquashResult`): flatten multiple `.surql` migrations into one while preserving checksums and version ordering.
+- **Schema drift hooks** (`checkSchemaDrift`, `defaultSchemaFilter`, `generatePrecommitConfig`, `getStagedSchemaFiles`, `DriftIssue`, `DriftReport`): git-hook / CI-friendly drift detection against a persisted snapshot.
+- **Schema watcher** (`watchSchema`, `WatchCallback`, `WatchHandle`, `WatchSchemaOptions`): filesystem watcher that re-runs drift checks on change with a configurable debounce.
+- **CLI** (#24): new `surql` binary (`./src/cli/main.ts`, exposed as `"./cli"` export). Subcommands:
+  - `surql migrate up|down|status|history|create|validate|generate|squash`
+  - `surql schema show|diff|generate|sync|export|tables|inspect|validate|check|hook-config|watch|visualize`
+  - `surql db init|ping|info|reset|query|version`
+  - `surql orchestrate deploy|status|validate`
+  - `surql settings` (dump resolved configuration)
+  - Built on `@cliffy/command`; honours `--config <path:string>` at every level.
+
+### Added — SurrealDB v3 correctness (#13, #14, #15)
+
+- **Buffered transactions** (#13): `Transaction.execute()` now queues statements client-side and flushes them as a single `BEGIN TRANSACTION; ...; COMMIT TRANSACTION;` request on `commit()`. SurrealDB v3 rejects bare `COMMIT TRANSACTION` / `CANCEL TRANSACTION` statements across isolated RPCs, so streaming the bookends no longer works.
+- **`IF NOT EXISTS` emitter** (#15): `generateTableSql`, `generateEdgeSql`, `generateAccessSql`, and `generateSchemaSql` accept an `ifNotExists: boolean` option. Set `true` to emit `DEFINE TABLE IF NOT EXISTS`, `DEFINE ACCESS IF NOT EXISTS`, etc., so schemas can be re-applied idempotently against a live v3 database.
+- **Integration CI pinned to SurrealDB v3.0.5** (#14): `.github/workflows/integration.yml` runs against `surrealdb/surrealdb:v3.0.5`; unit tests (publish jobs) exclude `integration*.test.ts`.
+
+### Added — Schema definition extensions
+
+- **HNSW index** (`hnswIndex`, `HnswDistanceType`) on top of the existing MTREE index.
+- **JWT URL + access durations** on `DEFINE ACCESS`.
+
+---
+
+## [1.1.0] - 2026-03-31
+
+### Added
+
+- **GROUP ALL support** (#5): Added `groupAll()` to the immutable Query builder for aggregating entire result sets without grouping fields. Added `mathMean()`, `mathSum()`, `mathMax()`, `mathMin()` expression aliases for SurrealDB math function names.
+- **type::record() helper** (#6): Added `recordRef(table, id)` function that generates `type::record('table:id')` SurrealQL, usable in SELECT expressions and WHERE conditions.
+- **SurrealDB function support in field values** (#7): Added `surqlFn(name, ...args)` for server-side function references (e.g. `time::now()`, `math::floor()`) that render as raw SurrealQL in create/update operations instead of being parameterized. Updated `quoteValue()` to detect and pass through `SurrealFnValue` objects.
+- **Result extraction helpers** (#8): Enhanced `extractScalar()` with optional `key` and `defaultValue` parameters for targeted field extraction and fallback values.
+- **Embedded SurrealDB protocols**: `ConnectionConfig` now accepts `protocol: 'mem' | 'rocksdb' | 'surrealkv' | 'surrealkv+versioned'` for in-process connections via the `@surrealdb/node` / `@surrealdb/wasm` engine packages. Persistent engines take an on-disk `path`; `mem` is ephemeral. Credential-less embedded connections skip signin automatically. Exported `EMBEDDED_PROTOCOLS` constant and `isEmbeddedProtocol()` type guard. `validateConnectionConfig()` now bypasses host/port/username/password checks when an embedded protocol is selected. Enables edge/device deployments where each host owns its own SurrealDB instance.
+
+### Fixed
+
+- **CI/CD**: Fixed publish workflow to properly publish to both JSR and npm on release tags. Resolved environment protection rule conflict for workflow_dispatch triggers. Upgraded GitHub Actions to Node.js 24 compatible versions.
+
+---
+
+## [1.0.1] - 2026-03-20
+
+### Fixed
+
+- **RecordID normalization**: RecordId objects from the SurrealDB JS SDK no longer leak through to consumers when no mapper is provided. The `mapResults()` base method now applies `normalizeSurrealRecord()` automatically, converting RecordId fields to plain strings in all CRUD operations (read, create, update, delete, merge, upsert, patch) regardless of whether a `.map()` function is supplied.
+
+### Added
+
+- **Tests**: Added `normalization.test.ts` covering automatic RecordID normalization across all query builder types.
+
+---
+
 ## [1.0.0-rc.2] - 2026-03-19
 
 ### Fixed
@@ -154,7 +250,7 @@
 
 ### Added - Core Features
 
-#### Authentication & Session Management
+#### 🔐 Authentication & Session Management
 
 - **Multi-Level Authentication**: Complete support for Root, Namespace, Database, and Scope-level authentication
 - **`signin()`** method supporting all credential types with comprehensive validation
@@ -175,7 +271,7 @@
   - `SignupError` - User registration failures
   - `ScopeAuthenticationError` - Scope-specific authentication issues
 
-#### Advanced CRUD Operations
+#### 🛠️ Advanced CRUD Operations
 
 - **`MergeQL`** class for partial data updates preserving existing fields
   - Smart merge operations that combine new data with existing records
@@ -192,7 +288,7 @@
   - Smart conditional logic handling both insert and update scenarios
   - Support for complex conflict resolution strategies
 
-#### Enhanced Query Builder Capabilities
+#### 📊 Enhanced Query Builder Capabilities
 
 - **`GroupByCapability`** mixin for advanced grouping functionality
   - Support for multiple grouping fields
@@ -215,7 +311,7 @@
   - New `page(pageNumber, pageSize)` method for simplified pagination
   - Integration with grouping and aggregation operations
 
-#### Architecture Improvements
+#### 🏗️ Architecture Improvements
 
 - **Capability-based mixin architecture** for composable query building
 - **Enhanced SurQLClient** with all new factory methods

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,175 @@
+# CLI
+
+v1.2.0 added a `surql` CLI (`./src/cli/main.ts`) for operator-level tasks: migrations, schema inspection, connection diagnostics, and multi-environment orchestration. It is published alongside the library as a Deno binary and as a JSR export (`@oneiriq/surql/cli`).
+
+## Install & invoke
+
+=== "Run from JSR"
+
+    ```bash
+    deno run \
+      --allow-read --allow-write --allow-net --allow-env --allow-sys \
+      --allow-run=git,deno \
+      jsr:@oneiriq/surql/cli \
+      --help
+    ```
+
+=== "Run from a clone"
+
+    ```bash
+    deno task cli --help
+    ```
+
+=== "Install as a named binary"
+
+    ```bash
+    deno install --global \
+      --allow-read --allow-write --allow-net --allow-env --allow-sys \
+      --allow-run=git,deno \
+      -n surql \
+      jsr:@oneiriq/surql/cli
+    ```
+
+All subcommands accept `--config <path:string>` (YAML or TOML). Without `--config`, settings are resolved from env vars, `.env`, `surql.yaml`, and `surql.toml` via the shared [settings loader](installation.md).
+
+## Top level
+
+```
+surql                                 # show help
+surql --version                       # print CLI version
+surql version                         # same
+surql --config ./surql.yaml <cmd>     # override config resolution
+surql settings                        # dump the resolved settings as JSON
+```
+
+## `surql migrate`
+
+Migration lifecycle commands. Most of these require a live database connection; `create` and `validate` operate on the filesystem only.
+
+| Command | Purpose |
+| --- | --- |
+| `surql migrate up [--directory <dir>] [--steps <n>] [--dry-run]` | Apply pending migrations. |
+| `surql migrate down [--directory <dir>] [--steps <n>] [--dry-run] [--yes]` | Roll back applied migrations (default 1 step; prompts for confirmation). |
+| `surql migrate status [--directory <dir>] [--format table\|json]` | Show applied + pending migrations. |
+| `surql migrate history [--format table\|json]` | Show the applied history recorded in `_migrations`. |
+| `surql migrate create <description> [--directory <dir>]` | Create a blank migration file. |
+| `surql migrate validate [--directory <dir>]` | Validate migration filenames and contents. |
+| `surql migrate generate <description> [--directory <dir>]` | Placeholder that falls back to `create`; the auto-generator is not yet ported from surql-py. |
+| `surql migrate squash [options]` | Flatten migrations into a single `.surql` file. See below. |
+
+### `surql migrate squash`
+
+Squash multiple `.surql` migrations into one atomic file while preserving checksums and ordering:
+
+```bash
+surql migrate squash \
+  --migrations migrations/ \
+  --output migrations/20260101000000_squashed.surql \
+  --from 20240101000001 \
+  --to   20240315000000 \
+  --description "squash_q1"
+```
+
+Flags:
+
+- `-m, --migrations <dir>` — migrations directory (default `migrations`).
+- `-o, --output <path>` — output file path (auto-generated if omitted).
+- `--from <version>` — inclusive start version.
+- `--to <version>` — inclusive end version.
+- `--dry-run` — preview without writing.
+- `--keep-originals` — keep original migration files after squash.
+- `--force` — remove the originals as part of the squash.
+- `--description <text>` — description for the squashed migration.
+
+## `surql schema`
+
+Schema inspection, validation, visualisation, and drift detection.
+
+| Command | Purpose |
+| --- | --- |
+| `surql schema show [table] [--format text\|json]` | Dump the live DB schema (or one table). |
+| `surql schema tables [--format table\|json]` | List tables + edges. |
+| `surql schema inspect <table>` | Detail fields, indexes, events. |
+| `surql schema export [--output <path>] [--table-name <t>] [--format json\|sql]` | Export the schema or a single table. |
+| `surql schema diff --schema <snapshot.json> [--format text\|json]` | Compare a snapshot file to the live DB. |
+| `surql schema validate --schema <snapshot.json> [--strict] [--format text\|json] [--output <path>]` | Validate a snapshot against the schema validator. |
+| `surql schema visualize --schema <snapshot.json> [--format mermaid\|graphviz\|ascii] [--output <path>] [--table-filter a,b] [--no-fields] [--no-edges]` | Generate a diagram. |
+| `surql schema check [--schema <dir>] [--snapshot <path>] [--fail-on-drift\|--no-fail-on-drift] [--show-diff] [--format text\|json]` | Git-hook / CI drift check. |
+| `surql schema hook-config [--schema <dir>] [--fail-on-drift\|--no-fail-on-drift]` | Print a ready-to-paste pre-commit YAML fragment. |
+| `surql schema watch [--schema <dir>] [--snapshot <path>] [--debounce <sec>]` | Watch files and report drift interactively. |
+| `surql schema generate` / `surql schema sync` | Placeholders; use `migrate create` + `migrate up`. |
+
+### Pre-commit integration
+
+Generate a pre-commit fragment and paste it into `.pre-commit-config.yaml`:
+
+```bash
+surql schema hook-config --schema schemas/ > .pre-commit/surql.yaml
+```
+
+## `surql db`
+
+Connectivity diagnostics and ad-hoc queries.
+
+| Command | Purpose |
+| --- | --- |
+| `surql db init` | Create the `_migrations` tracking table. |
+| `surql db ping [--verbose]` | Issue `RETURN 1;` against the configured connection. |
+| `surql db info [--format text\|json]` | Print resolved connection config (password masked). |
+| `surql db reset [--yes]` | **DESTRUCTIVE** — `REMOVE TABLE` every user table. Prompts unless `--yes`. |
+| `surql db query <query> [--format json\|table]` | Execute a raw SurrealQL query and print the result. |
+| `surql db version [--verbose]` | Print `INFO FOR DB` metadata. |
+
+## `surql orchestrate`
+
+Deploy migrations across multiple environments. Environment configuration is an array of `EnvironmentConfig` entries stored in JSON (default: `environments.json`).
+
+```json
+[
+  {
+    "name": "staging",
+    "connection": {
+      "host": "staging.db.internal", "port": "8000",
+      "namespace": "myapp", "database": "staging",
+      "username": "admin", "password": "..."
+    }
+  },
+  {
+    "name": "production",
+    "connection": {
+      "host": "prod.db.internal", "port": "8000",
+      "namespace": "myapp", "database": "prod",
+      "username": "admin", "password": "..."
+    }
+  }
+]
+```
+
+| Command | Purpose |
+| --- | --- |
+| `surql orchestrate deploy --environments staging,production [--strategy sequential\|parallel\|rolling\|canary] [--batch-size <n>] [--env-config <path>] [--migrations-dir <path>] [--dry-run]` | Roll migrations out to the listed environments. |
+| `surql orchestrate status --environments staging,production [--env-config <path>]` | Health-check a subset of environments. |
+| `surql orchestrate validate [--env-config <path>]` | Health-check every configured environment. |
+
+Strategies map to the orchestration API documented in [Orchestration](orchestration.md): `sequential`, `parallel`, `rolling` (honours `--batch-size`), and `canary`.
+
+## `surql settings`
+
+Prints the fully-resolved `Settings` object (env vars + `.env` + `surql.yaml` / `surql.toml`) as JSON. Use it to verify which config file a CI job is picking up:
+
+```bash
+surql --config ./ops/surql.production.yaml settings \
+  | jq '.database | { host, namespace, database, protocol }'
+```
+
+## Embedding the CLI
+
+If you need to wrap the CLI in your own Deno task runner, import the `run()` function from `@oneiriq/surql/cli` and pass your args. `buildRootCommand()` is also exposed so tests (or plugin authors) can introspect the command tree.
+
+```typescript
+import { run } from 'jsr:@oneiriq/surql/cli'
+
+await run(['migrate', 'up', '--directory', 'migrations'])
+```
+
+Errors raised from `@cliffy/command` validation are mapped to the CLI's `ExitCode.Usage`; everything else resolves to `ExitCode.Failure`.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,140 @@
+# Upgrade Guide
+
+Notes for upgrading existing surql integrations across the v1.1.0 → v1.2.0 → v1.3.x releases. No public APIs were removed; every change on this page is additive, and old call sites keep working.
+
+!!! note "Don't confuse with database migrations"
+    This page covers **library upgrades**. For SurrealDB schema migrations see [Migrations](migrations.md).
+
+## v1.1.0 → v1.2.0 (Parity + v3 correctness)
+
+### Required if you were issuing transactions manually
+
+SurrealDB v3 rejects bare `COMMIT TRANSACTION` / `CANCEL TRANSACTION` statements sent as standalone RPC calls. `Transaction.execute()` now **buffers statements client-side** and flushes them atomically on `commit()`.
+
+Most callers using the built-in `Transaction` class need no changes — the buffering is transparent. The observable differences:
+
+- `Transaction.execute(...)` returns an empty array. Per-statement results arrive on `commit()` instead.
+- Results you previously read from the `execute()` return value must move to post-commit lookups (or to explicit `RETURN` inside the buffered SurrealQL).
+- `Transaction.cancel()` no longer contacts the server.
+
+See [v3 Patterns](v3-patterns.md#buffered-begin-commit) for the full pattern.
+
+### Required if you hand-write `DEFINE` statements
+
+Re-applying `DEFINE TABLE` against an existing table errors out on v3. Pass `ifNotExists: true` to the schema emitters to make them idempotent:
+
+```typescript
+// Before (errors on second apply)
+const sql = generateSchemaSql({ tables, edges, access })
+
+// After
+const sql = generateSchemaSql({ tables, edges, access, ifNotExists: true })
+```
+
+`generateTableSql`, `generateEdgeSql`, and `generateAccessSql` accept the same flag.
+
+### Required if you targeted SurrealDB < v3
+
+Integration tests now run against `surrealdb/surrealdb:v3.0.5`. If your deployment still runs v1.x or v2.x:
+
+- Keep using the previous surql release (`1.1.0`), **or**
+- Upgrade SurrealDB to v3.0.5+ to benefit from the buffered-transaction fix and `IF NOT EXISTS` idempotency.
+
+### Optional — adopt the new helpers
+
+All additive; the old APIs keep working.
+
+- **Structured schema parser** (`parseDbInfo`, `parseTableInfo`, `parseFields`, `parseIndexes`, `parseEvents`, `parseAccess`, `parseEdgeInfo`) lets you round-trip a live schema into the code-first definition types and back.
+- **`loadSettings()` / `getSettings()`** replaces bespoke env + YAML/TOML loaders. Follows the same layered precedence as surql-py / surql-rs / surql-go.
+- **`GraphQuery`** replaces ad-hoc graph traversal strings. **v3 note**: the `->edge<depth>` suffix that surql-py emits is not valid on v3; the TS builder unrolls `depth` into repeated `->edge->?` hops instead.
+- **Migration squash** (`squashMigrations`) flattens old migrations into one `.surql` file while preserving checksums.
+- **Schema drift hooks** (`checkSchemaDrift`, `generatePrecommitConfig`, `watchSchema`) plug into git pre-commit and live dev loops.
+- **`surql` CLI** (`deno task cli …` or `jsr:@oneiriq/surql/cli`). See the [CLI reference](cli.md).
+
+## v1.2.0 → v1.3.0 (Query-UX wave)
+
+### Adopt `typeRecord` / `typeThing` for record references
+
+`recordRef(table, id)` still works (expression-context only). For references you want to splice into `SET` clauses or pass to CRUD helpers, use `typeRecord(table, id)` — it carries the `__surqlFn` marker so `quoteValue()` renders it inline instead of parameterising it:
+
+```typescript
+// Before
+await updateRecord(db, 'task', taskId, {
+  owner: raw(`type::record('user:${userId}')`),
+})
+
+// After
+await updateRecord(db, typeRecord('task', taskId), {
+  owner: typeRecord('user', userId),
+})
+```
+
+`typeThing` is a parity alias for callers porting py / rs / go code — both emit the v3-valid `type::record(...)` form.
+
+### `FunctionValueExpression` unifies expression + value contexts
+
+Every factory added in 1.3.0 (`count`, `countIf`, `mathAbs/Ceil/Floor/Round/Sum/Mean/Max/Min`, `stringLen/Lower/Upper/Concat`, `timeNow`, `timeFormat`, `arrayLength/Contains/Distinct/Flatten`) returns a `FunctionValueExpression`. The same value works in both SELECT/WHERE **and** SET without re-wrapping:
+
+```typescript
+// Before — two distinct wraps for the same function
+await createRecord(db, 'audit', { ts: surqlFn('time::now') })
+const now = func('time::now')               // for SELECT
+
+// After — one value, both contexts
+const now = timeNow()
+await createRecord(db, 'audit', { ts: now })
+await aggregateRecords({ table: 'audit', select: { now }, groupAll: true, client: db })
+```
+
+### Prefer `aggregateRecords` over hand-rolled aggregation SurrealQL
+
+```typescript
+// Before
+const sql = `
+  SELECT network, count() AS total, math::sum(strength) AS strengthSum
+  FROM memory_entry
+  GROUP BY network
+`
+const raw = await db.query(sql)
+const rows = extractResult(raw)
+
+// After
+const rows = await aggregateRecords({
+  table: 'memory_entry',
+  select: { total: count(), strengthSum: mathSum('strength') },
+  groupBy: ['network'],
+  client: db,
+})
+```
+
+### Adopt `extractMany` / `hasResult` for parity code
+
+If you are porting code from surql-py / surql-rs / surql-go, replace `extractResult` / `hasResults` with the new aliases so the call sites read identically across languages. Both pairs are permanent; use whichever matches the surrounding code.
+
+### Overload-based `updateRecord` / `getRecord`
+
+The `(db, table, id, ...)` signatures are unchanged. Additionally, you can pass a `typeRecord(...)` value as a single reference:
+
+```typescript
+const ref = typeRecord('task', taskId)
+const task = await getRecord<Task>(db, ref)
+await updateRecord<Task>(db, ref, { status: 'done' })
+```
+
+## v1.3.0 → v1.3.1
+
+CI-only fix: `src/test/integration*.test.ts` is now excluded from the publish-time unit test jobs so JSR/npm publishes no longer require a live SurrealDB container. No user-facing code changes.
+
+## v1.3.1 → v1.3.2
+
+Documentation refresh only. No code changes. The rendered site now covers every wave that landed since v1.0.0 (v3 patterns, query UX, CLI, upgrade notes). `deno.json` is bumped to `1.3.2` so the refreshed docs publish alongside the version.
+
+## Developer experience — enable the pre-push hook
+
+v1.3.0 ships a pre-push hook that mirrors the CI `fmt --check` / `lint` / `check` gates:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Opt into the integration suite (requires a running SurrealDB v3.0.5 container) by exporting `SURQL_PRE_PUSH_INTEGRATION=1`. See [`CONTRIBUTING.md`](https://github.com/Oneiriq/surql/blob/main/CONTRIBUTING.md).

--- a/docs/query-ux.md
+++ b/docs/query-ux.md
@@ -1,0 +1,169 @@
+# Query UX
+
+The v1.3.x query-UX wave fills in first-class helpers for the patterns callers were previously reaching into `raw()` / `surqlFn()` for. This page shows the before/after for each helper.
+
+## `typeRecord` / `typeThing` references
+
+`typeRecord(table, id?)` produces a `SurrealFnValue` that renders as `type::record('table:id')` (or `type::record('table')` when `id` is omitted). `typeThing` is a parity alias for surql-py / surql-rs / surql-go callers; both emit the v3-valid form.
+
+**Before:**
+
+```typescript
+import { raw } from 'jsr:@oneiriq/surql'
+
+await db.query(
+  `UPDATE task:${taskId} SET owner = type::record('user:${userId}')`,
+)
+```
+
+**After:**
+
+```typescript
+import { typeRecord, updateRecord } from 'jsr:@oneiriq/surql'
+
+await updateRecord(db, typeRecord('task', taskId), {
+  owner: typeRecord('user', userId),
+})
+```
+
+The nested `typeRecord` call renders inline in the `SET` clause because `SurrealFnValue` carries the `__surqlFn` marker that `quoteValue()` recognises.
+
+## Function factories
+
+v1.3.0 expanded the function catalogue so callers can compose SurrealDB math / string / count / time functions from typed factories instead of raw strings.
+
+### New factories
+
+| Category | Factory | Emits |
+| --- | --- | --- |
+| Count | `count()`, `count(expr)` | `count()`, `count(expr)` |
+| Count | `countIf(condition)` | `count(IF <cond> THEN 1 END)` |
+| Math | `mathAbs`, `mathCeil`, `mathFloor`, `mathRound` | `math::abs`, `math::ceil`, `math::floor`, `math::round` |
+| Math | `mathSum`, `mathMean`, `mathMax`, `mathMin` | `math::sum`, `math::mean`, `math::max`, `math::min` |
+| String | `stringLen`, `stringLower`, `stringUpper`, `stringConcat` | `string::len`, `string::lowercase`, `string::uppercase`, `string::concat` |
+| Time | `timeNow()`, `timeFormat(expr, format)` | `time::now()`, `time::format(expr, format)` |
+| Array | `arrayLength`, `arrayContains`, `arrayDistinct`, `arrayFlatten` | `array::len`, `array::contains`, `array::distinct`, `array::flatten` |
+| Record | `recordRef(table, id?)` | `type::record('table:id')` (expression form) |
+
+Short-form aliases retained for pre-1.3.0 callers: `abs_`, `ceil`, `floor`, `round_`, `upper`, `lower`, `concat`, `stringLength`, `sum_`, `avg`, `min_`, `max_`.
+
+### `countIf` example
+
+**Before:**
+
+```typescript
+import { raw } from 'jsr:@oneiriq/surql'
+
+const failing = raw('count(IF status = "failed" THEN 1 END)')
+```
+
+**After:**
+
+```typescript
+import { countIf } from 'jsr:@oneiriq/surql'
+
+const failing = countIf('status = "failed"')
+```
+
+## `FunctionValueExpression` — one value, two contexts
+
+Every factory above returns a `FunctionValueExpression`: it implements `FunctionExpression` **and** `SurrealFnValue`. The same value can be handed to `SELECT` / `WHERE` expression slots **and** to a `SET` field value without re-wrapping:
+
+```typescript
+import { createRecord, timeNow, updateRecord } from 'jsr:@oneiriq/surql'
+
+// SET clause — renders inline as time::now() (not parameterised).
+await createRecord(db, 'audit', { ts: timeNow(), action: 'login' })
+await updateRecord(db, 'user', 'alice', { lastSeen: timeNow() })
+
+// SELECT expression — same value, also valid here.
+import { aggregateRecords, field } from 'jsr:@oneiriq/surql'
+
+await aggregateRecords({
+  table: 'request',
+  select: { now: timeNow() },
+  groupAll: true,
+  client: db,
+})
+```
+
+Previously you needed to reach for `surqlFn('time::now')` when you wanted the `SET`-clause form and for `func('time::now')` (or a `raw(...)`) when you wanted the expression form.
+
+## `extractMany` and `hasResult` aliases
+
+The result extraction helpers gained parity aliases with surql-py (`extract_many`, `has_result`):
+
+```typescript
+import { extractMany, hasResult } from 'jsr:@oneiriq/surql'
+
+const raw = await db.query('SELECT * FROM user WHERE active = true')
+const users = extractMany<User>(raw)
+
+if (hasResult(raw)) {
+  console.log(`found ${users.length} active users`)
+}
+```
+
+`extractResult` and `hasResults` remain available; `extractMany` and `hasResult` are thin aliases so code ported from py/rs/go reads identically.
+
+## `aggregateRecords`
+
+One-shot aggregation helper. Pass named SELECT expressions keyed by the alias you want each column to use:
+
+```typescript
+import { aggregateRecords, count, countIf, mathSum } from 'jsr:@oneiriq/surql'
+
+const counts = await aggregateRecords({
+  table: 'memory_entry',
+  select: {
+    total: count(),
+    failed: countIf('status = "failed"'),
+    strengthSum: mathSum('strength'),
+  },
+  groupBy: ['network'],
+  orderBy: [{ field: 'network', direction: 'ASC' }],
+  client: db,
+})
+
+// counts[0] === { network: 'foo', total: 12, failed: 2, strengthSum: 48 }
+```
+
+Options:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `table` | `string` | Required. Escaped via `escapeTable()`. |
+| `select` | `Record<string, Expression>` | Required. At least one alias → expression. |
+| `groupBy` | `readonly string[]` | Mutually exclusive with `groupAll`. |
+| `groupAll` | `boolean` | Emits `GROUP ALL`. Array is always a single row. |
+| `where` | `string` | Raw predicate spliced after `WHERE`. |
+| `orderBy` | `{ field, direction?: 'ASC' \| 'DESC' }[]` | Appended in order. |
+| `limit` | `number` | Appended as `LIMIT n`. |
+| `client` | `Surreal` | Active connection. |
+
+Throws if `select` is empty or if both `groupAll` and `groupBy` are set.
+
+## CRUD overloads: `updateRecord(db, ref, data)` / `getRecord(db, ref)`
+
+`getRecord` and `updateRecord` now accept a `typeRecord()` reference in place of the `(table, id)` pair. The original signatures still work.
+
+**Before:**
+
+```typescript
+import { getRecord, updateRecord } from 'jsr:@oneiriq/surql'
+
+const task = await getRecord<Task>(db, 'task', taskId)
+await updateRecord<Task>(db, 'task', taskId, { status: 'done' })
+```
+
+**After:**
+
+```typescript
+import { getRecord, typeRecord, updateRecord } from 'jsr:@oneiriq/surql'
+
+const ref = typeRecord('task', taskId)
+const task = await getRecord<Task>(db, ref)
+await updateRecord<Task>(db, ref, { status: 'done' })
+```
+
+Useful when the reference already exists (e.g. returned by `aggregateRecords` or flowed through a domain-layer helper) — you no longer have to split it back into `(table, id)` at the call site.

--- a/docs/v3-patterns.md
+++ b/docs/v3-patterns.md
@@ -1,0 +1,104 @@
+# SurrealDB v3 Patterns
+
+surql targets **SurrealDB v3** for integration testing and CI (pinned to `surrealdb/surrealdb:v3.0.5`). Several SurrealQL behaviours changed between v1/v2 and v3; surql emits v3-valid SurrealQL by default and wraps the awkward bits in first-class helpers. This page documents the patterns you must follow to produce v3-valid SurrealQL.
+
+## Buffered `BEGIN` / `COMMIT`
+
+SurrealDB v3 **rejects bare `COMMIT TRANSACTION` / `CANCEL TRANSACTION` statements when they are sent as isolated RPC requests**. A transaction must be submitted as a single `BEGIN ... COMMIT` batch in one `query()` call.
+
+surql handles this for you by buffering every call to `Transaction.execute()` client-side and flushing the batch on `commit()`:
+
+```typescript
+import { transaction } from 'jsr:@oneiriq/surql'
+
+const tx = transaction(db)
+await tx.begin()
+await tx.execute('CREATE user SET name = $name', { name: 'Alice' })
+await tx.execute('CREATE user SET name = $name', { name: 'Bob' })
+await tx.commit() // issues BEGIN TRANSACTION; ...; COMMIT TRANSACTION; in one RPC
+```
+
+!!! warning "Do not stream statements"
+    Splitting `BEGIN TRANSACTION` and `COMMIT TRANSACTION` across separate `db.query()` calls worked on v1/v2 but fails on v3 with `Found COMMIT TRANSACTION, but ...`.
+
+`Transaction.cancel()` discards the buffer client-side without ever contacting the server. `Transaction` also implements `Symbol.asyncDispose` so `await using tx = transaction(db)` auto-cancels if the block exits without committing.
+
+## `IF NOT EXISTS` for idempotent `DEFINE`
+
+SurrealDB v3 supports `IF NOT EXISTS` on `DEFINE TABLE`, `DEFINE FIELD`, `DEFINE ACCESS`, etc. surql's SQL emitters accept an `ifNotExists` option so generated schemas can be re-applied against a live database without `Table ... already exists` errors:
+
+```typescript
+import {
+  generateAccessSql,
+  generateEdgeSql,
+  generateSchemaSql,
+  generateTableSql,
+} from 'jsr:@oneiriq/surql'
+
+generateTableSql(userTable, { ifNotExists: true })
+// → DEFINE TABLE IF NOT EXISTS user SCHEMAFULL;
+//   DEFINE FIELD name ON TABLE user TYPE string;
+//   ...
+
+generateEdgeSql(authored, { ifNotExists: true })
+generateAccessSql(jwtAccess, 'DATABASE', { ifNotExists: true })
+
+generateSchemaSql({
+  tables: [userTable, postTable],
+  edges: [authored],
+  access: [jwtAccess],
+  ifNotExists: true,
+})
+```
+
+`ifNotExists` also applies to the secondary `DEFINE TABLE ... PERMISSIONS` line when table-level permissions are configured.
+
+## Unrolled graph depth
+
+SurrealDB v3 dropped the `<depth>` suffix that v1/v2 accepted on edge traversals (`user:alice->follows2`). The `GraphQuery` builder emits v3-valid SurrealQL by expanding a positive `depth` into repeated `->edge->?` hops:
+
+```typescript
+import { GraphQuery } from 'jsr:@oneiriq/surql'
+
+// Depth 1 (the default) emits a single edge step.
+const direct = GraphQuery.from('user:alice').out('follows').render()
+// → SELECT * FROM user:alice->follows;
+
+// Depth 3 unrolls into three hops producing a v3-valid traversal path.
+const threeHops = GraphQuery.from('user:alice').out('follows', 3).render()
+// → SELECT * FROM user:alice->follows->?->follows->?->follows->?;
+
+// Incoming and bidirectional use the same rules.
+GraphQuery.from('post:article1').in_('likes').render()
+// → SELECT * FROM post:article1<-likes;
+
+GraphQuery.from('user:alice').both('knows', 2).render()
+// → SELECT * FROM user:alice<->knows<->?<->knows<->?;
+```
+
+A `depth` of `1` or `undefined` collapses to the single-edge form. Invalid values (non-integer, ≤ 0, or non-finite) raise `GraphQueryError`.
+
+## `type::record()` instead of `type::thing()`
+
+SurrealDB v3 renamed `type::thing()` to `type::record()`. surql's `typeRecord(table, id?)` / `typeThing(table, id?)` helpers (the latter is a parity alias for the py/rs/go ports) always emit the v3-valid form:
+
+```typescript
+import { typeRecord, typeThing } from 'jsr:@oneiriq/surql'
+
+typeRecord('task', '123').toSurQL() // → type::record('task:123')
+typeThing('task', '123').toSurQL()  // → type::record('task:123') (same output)
+```
+
+See [Query UX](query-ux.md) for the CRUD overloads that accept these refs directly.
+
+## CI pin
+
+Integration tests run against `surrealdb/surrealdb:v3.0.5` (see `.github/workflows/integration.yml`). The publish-time unit test jobs exclude `src/test/integration*.test.ts` so JSR/npm releases do not require a live container. To run the integration tests locally:
+
+```bash
+docker run -d -p 8000:8000 --name surrealdb \
+  surrealdb/surrealdb:v3.0.5 start --user root --pass root memory
+SURQL_PRE_PUSH_INTEGRATION=1 deno task test
+```
+
+The `.githooks/pre-push` hook opts into the integration suite with the same env var (see [Contributing](https://github.com/Oneiriq/surql/blob/main/CONTRIBUTING.md)).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,17 +71,21 @@ nav:
   - Getting Started:
       - Installation: installation.md
       - Quick Start: quickstart.md
+      - Upgrade Guide: migration.md
   - Guides:
       - Schema Definition: schema.md
       - Migrations: migrations.md
       - Query Builder: queries.md
+      - Query UX: query-ux.md
       - Query Hints: query_hints.md
       - Caching: caching.md
       - Streaming: streaming.md
       - Orchestration: orchestration.md
       - Versioning & Rollback: versioning_rollback.md
+      - SurrealDB v3 Patterns: v3-patterns.md
   - Reference:
       - API: api/index.md
+      - CLI: cli.md
       - Visualization: visualization.md
   - Examples: examples/index.md
   - Changelog: changelog.md


### PR DESCRIPTION
## Summary

Brings the mkdocs-material docs site in sync with the code surface that landed between v1.1.0 and v1.3.1.

### Pages added
- `docs/v3-patterns.md` — buffered BEGIN/COMMIT, `IF NOT EXISTS`, unrolled GraphQuery depth, `type::record()` migration, CI pin to v3.0.5.
- `docs/query-ux.md` — `typeRecord`/`typeThing`, function factories (`countIf`, `math*`, `string*`, `timeNow`), `FunctionValueExpression`, `extractMany`/`hasResult`, `aggregateRecords`, CRUD overloads — each with before/after.
- `docs/cli.md` — full reference for `surql migrate|schema|db|orchestrate|settings` including squash, drift, visualize, hook-config, embedding via `run()`.
- `docs/migration.md` — upgrade guide v1.1.0 → v1.2.0 → v1.3.x.

### Updated
- `docs/changelog.md` + `CHANGELOG.md` — backfilled 1.2.0/1.3.0/1.3.1/1.3.2 (changelog had stalled at 1.0.0-rc.2).
- `README.md` — new lead example uses `typeRecord`, `timeNow`, `aggregateRecords`, `count`/`countIf`/`mathSum`, `updateRecord`/`getRecord` overloads; CLI section; v3 requirement; cross-links.
- `mkdocs.yml` nav — Upgrade Guide under Getting Started; Query UX + SurrealDB v3 Patterns under Guides; CLI under Reference.
- `deno.json` — version 1.3.1 → 1.3.2.

## Test plan

- [x] `deno task fmt --check` clean (164 files)
- [x] `deno task lint` clean
- [x] `deno task check` clean
- [x] `mkdocs build --strict` clean

## Deferred
- `docs/api/index.md` stays hand-curated (full `deno doc`-backed reference is a follow-up).
- Schema page rewrite to deep-link the structured parser + HNSW/JWT extensions deferred; currently surfaced via changelog + upgrade guide.

Refs #37.