### PR TITLE
feat(#42): point CI at aur0 org self-hosted runner

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -37,7 +37,7 @@ env:
 jobs:
   audit:
     name: npm audit (npm: specifiers from deno.json)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   code_quality:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     strategy:
       matrix:
         deno-version: [v2.x]

--- a/.github/workflows/dep-review.yml
+++ b/.github/workflows/dep-review.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   dep-review:
     name: Dependency Review
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v5
 
@@ -39,7 +39,7 @@ jobs:
           path: site/
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: build
     environment:
       name: github-pages

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   integration:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v5
       - name: Setup Deno

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -92,7 +92,7 @@ jobs:
   integration:
     name: Integration (Deno ${{ matrix.deno }} / surrealdb:${{ matrix.surreal }})
     if: github.event_name != 'schedule' || github.event.schedule == '0 3 * * *'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   lint-pr-title:
     name: Conventional Commit PR title
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
     if: |
       github.event_name == 'release' ||
       (github.event_name == 'workflow_dispatch' && (inputs.target == 'jsr' || inputs.target == 'both'))
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     permissions:
       contents: read
       id-token: write
@@ -47,7 +47,7 @@ jobs:
     if: |
       (github.event_name == 'release' && !github.event.release.prerelease) ||
       (github.event_name == 'workflow_dispatch' && (inputs.target == 'npm' || inputs.target == 'both'))
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     environment: ${{ github.event_name == 'release' && 'publish' || '' }}
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     strategy:
       matrix:
         deno-version: [v2.x]


### PR DESCRIPTION
Closes #42. Retargets `ubuntu-latest` -> `[self-hosted, Linux, X64]` so CI runs on aur0-oneiriq (org-level self-hosted). Zero GitHub-hosted minutes for these jobs.

Merged after this lands: every push/PR on surql hits aur0, no billed minutes.