### PR TITLE
chore(license): Apache-2.0 with NOTICE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 !mod.ts
 !README.md
 !LICENSE
+!NOTICE
 !flake.nix
 !flake.lock
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,202 @@
-MIT License
 
-Copyright (c) 2025 Shon Thomas
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+   1. Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,18 @@
+surql
+Copyright (c) 2026 Shon Thomas
+
+This product includes software developed by Shon Thomas
+(https://github.com/Oneiriq/surql).
+
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Per Section 4 of the License, redistributions of source code or binary
+forms must retain this NOTICE file in any distribution. If you
+substantially modify surql, you must clearly mark the modified files.
+You must not use the names "surql", "oneiriq-surql", or "Shon Thomas"
+to endorse or promote derivative products without prior written
+permission.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # surql
 
 [![JSR Version](https://img.shields.io/jsr/v/@oneiriq/surql)](https://jsr.io/@oneiriq/surql)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: Apache 2.0](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![SurrealDB](https://img.shields.io/badge/SurrealDB-v3-ff00a0)](https://surrealdb.com/)
 
 Code-first database toolkit for [SurrealDB](https://surrealdb.com/). Type-safe query builder, schema/migration engine, orchestrator, and `surql` CLI — all from TypeScript, for Deno and Node.js.
@@ -137,7 +137,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+Apache License 2.0 — see [LICENSE](LICENSE).
 
 ## Python
 

--- a/deno.json
+++ b/deno.json
@@ -1,92 +1,95 @@
 {
-	"lock": true,
-
-	"name": "@oneiriq/surql",
-	"version": "1.3.2",
-	"license": "MIT",
-	"exports": {
-		".": "./mod.ts",
-		"./cli": "./src/cli/main.ts"
-	},
-
-	"bin": {
-		"surql": "./src/cli/main.ts"
-	},
-
-	"tasks": {
-		"test": "deno test --ignore='src/test/auth.test.ts' --allow-read --allow-write --allow-net --allow-sys --allow-env --allow-run=git,deno",
-		"test:watch": "deno test --ignore='src/test/auth.test.ts' --allow-read --allow-write --allow-net --allow-sys --allow-env --allow-run=git,deno --watch",
-		"test:coverage": "deno test --ignore='src/test/auth.test.ts' --allow-read --allow-write --allow-net --allow-sys --allow-env --allow-run=git,deno --coverage=coverage/",
-		"coverage": "deno coverage coverage/ --html",
-		"bench": "deno bench --allow-read --allow-write --allow-net --allow-sys",
-		"build:npm": "deno run -A scripts/build_npm.ts",
-		"cli": "deno run --allow-read --allow-write --allow-net --allow-env --allow-sys --allow-run=git,deno src/cli/main.ts",
-		"fmt": "deno fmt",
-		"fmt:check": "deno fmt --check",
-		"lint": "deno lint",
-		"check": "deno check src/cli/main.ts src/cli/mod.ts mod.ts"
-	},
-
-	"compilerOptions": {
-		"strict": true
-	},
-
-	"lint": {
-		"include": ["src/"],
-		"exclude": [
-			"src/fixtures/**/*.ts",
-			"dist/"
-		],
-		"rules": {
-			"tags": ["recommended"],
-			"include": [
-				"ban-untagged-todo",
-				"no-unused-vars",
-				"no-explicit-any",
-				"no-irregular-whitespace",
-				"default-param-last",
-				"no-deprecated-deno-api",
-				"no-import-assign",
-				"no-sloppy-imports",
-				"no-delete-var",
-				"no-useless-rename",
-				"no-extra-boolean-cast",
-				"no-invalid-regexp"
-			],
-			"exclude": [
-				"require-await"
-			]
-		}
-	},
-
-	"fmt": {
-		"useTabs": false,
-		"lineWidth": 120,
-		"indentWidth": 2,
-		"semiColons": false,
-		"singleQuote": true,
-		"proseWrap": "preserve",
-		"include": ["src/"],
-		"exclude": [
-			"src/fixtures/**/*.ts"
-		]
-	},
-
-	"imports": {
-		"@cliffy/command": "jsr:@cliffy/command@^1",
-		"@std/assert": "jsr:@std/assert@^1.0.0",
-		"@std/testing": "jsr:@std/testing@^1.0.0",
-		"@std/testing/bdd": "jsr:@std/testing@^1.0.0/bdd",
-		"@std/testing/mock": "jsr:@std/testing@^1.0.0/mock",
-		"@std/streams": "jsr:@std/streams@^1.0.0",
-		"@std/async": "jsr:@std/async@^1.0.0",
-		"@std/fmt/colors": "jsr:@std/fmt@^1.0.0/colors",
-		"@std/yaml": "jsr:@std/yaml@^1.0.0",
-		"@std/toml": "jsr:@std/toml@^1.0.0",
-		"zod": "npm:zod@^4.0.0",
-		"zod/v4/core": "npm:zod@^4.0.0/v4/core",
-		"surrealdb": "npm:surrealdb@^2.0.0"
-	},
-
-	"exclude": [".claude/", "dist/", "npm/", "examples/"]
+  "lock": true,
+  "name": "@oneiriq/surql",
+  "version": "1.3.2",
+  "license": "Apache-2.0",
+  "exports": {
+    ".": "./mod.ts",
+    "./cli": "./src/cli/main.ts"
+  },
+  "bin": {
+    "surql": "./src/cli/main.ts"
+  },
+  "tasks": {
+    "test": "deno test --ignore='src/test/auth.test.ts' --allow-read --allow-write --allow-net --allow-sys --allow-env --allow-run=git,deno",
+    "test:watch": "deno test --ignore='src/test/auth.test.ts' --allow-read --allow-write --allow-net --allow-sys --allow-env --allow-run=git,deno --watch",
+    "test:coverage": "deno test --ignore='src/test/auth.test.ts' --allow-read --allow-write --allow-net --allow-sys --allow-env --allow-run=git,deno --coverage=coverage/",
+    "coverage": "deno coverage coverage/ --html",
+    "bench": "deno bench --allow-read --allow-write --allow-net --allow-sys",
+    "build:npm": "deno run -A scripts/build_npm.ts",
+    "cli": "deno run --allow-read --allow-write --allow-net --allow-env --allow-sys --allow-run=git,deno src/cli/main.ts",
+    "fmt": "deno fmt",
+    "fmt:check": "deno fmt --check",
+    "lint": "deno lint",
+    "check": "deno check src/cli/main.ts src/cli/mod.ts mod.ts"
+  },
+  "compilerOptions": {
+    "strict": true
+  },
+  "lint": {
+    "include": [
+      "src/"
+    ],
+    "exclude": [
+      "src/fixtures/**/*.ts",
+      "dist/"
+    ],
+    "rules": {
+      "tags": [
+        "recommended"
+      ],
+      "include": [
+        "ban-untagged-todo",
+        "no-unused-vars",
+        "no-explicit-any",
+        "no-irregular-whitespace",
+        "default-param-last",
+        "no-deprecated-deno-api",
+        "no-import-assign",
+        "no-sloppy-imports",
+        "no-delete-var",
+        "no-useless-rename",
+        "no-extra-boolean-cast",
+        "no-invalid-regexp"
+      ],
+      "exclude": [
+        "require-await"
+      ]
+    }
+  },
+  "fmt": {
+    "useTabs": false,
+    "lineWidth": 120,
+    "indentWidth": 2,
+    "semiColons": false,
+    "singleQuote": true,
+    "proseWrap": "preserve",
+    "include": [
+      "src/"
+    ],
+    "exclude": [
+      "src/fixtures/**/*.ts"
+    ]
+  },
+  "imports": {
+    "@cliffy/command": "jsr:@cliffy/command@^1",
+    "@std/assert": "jsr:@std/assert@^1.0.0",
+    "@std/testing": "jsr:@std/testing@^1.0.0",
+    "@std/testing/bdd": "jsr:@std/testing@^1.0.0/bdd",
+    "@std/testing/mock": "jsr:@std/testing@^1.0.0/mock",
+    "@std/streams": "jsr:@std/streams@^1.0.0",
+    "@std/async": "jsr:@std/async@^1.0.0",
+    "@std/fmt/colors": "jsr:@std/fmt@^1.0.0/colors",
+    "@std/yaml": "jsr:@std/yaml@^1.0.0",
+    "@std/toml": "jsr:@std/toml@^1.0.0",
+    "zod": "npm:zod@^4.0.0",
+    "zod/v4/core": "npm:zod@^4.0.0/v4/core",
+    "surrealdb": "npm:surrealdb@^2.0.0"
+  },
+  "exclude": [
+    ".claude/",
+    "dist/",
+    "npm/",
+    "examples/"
+  ]
 }


### PR DESCRIPTION
Same shape as the surql-rs / sigilbuzz / cosmiq-graphql change. Replaces GPL-3.0 LICENSE with Apache-2.0 verbatim, adds a NOTICE file with attribution + endorsement clause, fixes the README badge that previously claimed MIT, and sets the deno.json license field to Apache-2.0.