### PR TITLE
chore: trim auto-trigger workflows + bump to 1.3.3

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -11,25 +11,14 @@ name: Security Audit
 # is committed. JSR-only updates are still caught by `nightly.yml` via
 # the Deno version matrix.
 
+# Cost-conscious surface: manual-only for now (3000 action minutes/month
+# budget). Re-enable PR/push/schedule when the budget allows.
 on:
-  pull_request:
-    branches:
-      - main
-      - 'release/**'
-    paths:
-      - 'deno.json'
-      - 'deno.lock'
-      - '.github/workflows/audit.yml'
-  push:
-    branches:
-      - main
-    paths:
-      - 'deno.json'
-      - 'deno.lock'
-      - '.github/workflows/audit.yml'
-  schedule:
-    - cron: '0 4 * * *'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,17 @@
 name: CI
 
+# Cost-conscious trigger surface: PR-only. Pushes to main don't fire CI
+# directly — the merge must already have passed the PR-triggered run,
+# and post-merge re-runs cost minutes for no incremental signal.
 on:
-  push:
   pull_request:
+    branches: [main, 'release/**']
+
+# New commits to a PR cancel any in-flight CI run on the same branch.
+# Reduces wasted runner minutes when force-pushing or quick-fixing a PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,10 +1,14 @@
 name: Integration Tests
 
+# Cost-conscious surface: manual-only. Integration spins a SurrealDB
+# container per run; expensive when fired on every push. Trigger from
+# the Actions UI when integration sign-off is needed.
 on:
-  push:
-    branches: [main]
-  pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,9 +1,13 @@
 name: Nightly
 
+# Cost-conscious surface: manual-only for now. The cron consumed ~30 min
+# per night across the OS x Deno matrix; re-enable once budget allows.
 on:
-  schedule:
-    - cron: '0 3 * * *'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "lock": true,
   "name": "@oneiriq/surql",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "license": "Apache-2.0",
   "exports": {
     ".": "./mod.ts",


### PR DESCRIPTION
Trims auto-trigger surface to fit the 3000-minute monthly budget. Disabled auto-triggers on audit / integration / nightly (now workflow_dispatch only); ci.yml dropped its push trigger and now runs only on pull_request with cancel-in-progress concurrency. Keep list per directive: docs.yml, PR-triggered code checks, dep-review, pr-title, publish.yml.

Bumps deno.json 1.3.2 → 1.3.3 so creating the v1.3.3 release fires publish.yml through the `publish` environment with the rotated NPM_TOKEN, replacing the stale MIT-licensed NPM artifact.