### PR TITLE
chore(security): close code-scanning alerts (workflow permissions + sanitization)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,6 +3,9 @@ name: Code Check
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,9 @@ on:
           - both
         default: both
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ name: Unit Tests
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/src/query/helpers.ts
+++ b/src/query/helpers.ts
@@ -30,7 +30,12 @@ export function quoteValue(value: unknown): string {
   ) {
     return (value as { surql: string }).surql
   }
-  if (typeof value === 'string') return `'${value.replace(/'/g, "\\'")}'`
+  if (typeof value === 'string') {
+    // Escape backslashes first, then single quotes, so that an attacker
+    // can't smuggle a closing quote via `\'` (CodeQL js/incomplete-sanitization).
+    const escaped = value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+    return `'${escaped}'`
+  }
   if (typeof value === 'boolean') return value ? 'true' : 'false'
   if (typeof value === 'number') return String(value)
   if (Array.isArray(value)) return `[${value.map(quoteValue).join(', ')}]`

--- a/src/test/helpers.test.ts
+++ b/src/test/helpers.test.ts
@@ -19,6 +19,14 @@ describe('quoteValue', () => {
     assertEquals(quoteValue("it's"), "'it\\'s'")
   })
 
+  it('should escape backslashes before quotes (no quote-smuggle)', () => {
+    // Regression for CodeQL js/incomplete-sanitization: an attacker passing
+    // a literal backslash followed by a single quote must not be able to
+    // produce a string that closes the SurrealQL string and continues as code.
+    assertEquals(quoteValue("a\\'; SELECT * FROM users; --"), "'a\\\\\\'; SELECT * FROM users; --'")
+    assertEquals(quoteValue('back\\slash'), "'back\\\\slash'")
+  })
+
   it('should return true/false for booleans', () => {
     assertEquals(quoteValue(true), 'true')
     assertEquals(quoteValue(false), 'false')

--- a/src/test/operators.test.ts
+++ b/src/test/operators.test.ts
@@ -214,6 +214,12 @@ describe('operators', () => {
       assertEquals(expr.toSurQL(), "name = 'O\\'Brien'")
     })
 
+    it('should escape backslashes before quotes (no quote-smuggle)', () => {
+      // Regression for CodeQL js/incomplete-sanitization on src/types/operators.ts.
+      const expr = eq('name', "a\\'; SELECT * FROM users; --")
+      assertEquals(expr.toSurQL(), "name = 'a\\\\\\'; SELECT * FROM users; --'")
+    })
+
     it('should handle false boolean', () => {
       const expr = eq('active', false)
       assertEquals(expr.toSurQL(), 'active = false')

--- a/src/types/operators.ts
+++ b/src/types/operators.ts
@@ -30,7 +30,12 @@ export type Operator = ComparisonOperator | LogicOperator
  */
 function quoteValue(value: unknown): string {
   if (value === null || value === undefined) return 'NONE'
-  if (typeof value === 'string') return `'${value.replace(/'/g, "\\'")}'`
+  if (typeof value === 'string') {
+    // Escape backslashes first, then single quotes, so that an attacker
+    // can't smuggle a closing quote via `\'` (CodeQL js/incomplete-sanitization).
+    const escaped = value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+    return `'${escaped}'`
+  }
   if (typeof value === 'boolean') return value ? 'true' : 'false'
   if (typeof value === 'number') return String(value)
   if (Array.isArray(value)) return `[${value.map(quoteValue).join(', ')}]`


### PR DESCRIPTION
Closes 11 open code-scanning alerts.

## Workflow permissions (medium x9)

Rule: `actions/missing-workflow-permissions`

Added workflow-level `permissions: contents: read` to:
- `.github/workflows/ci.yml` (alerts at lines 21, 24)
- `.github/workflows/check.yml` (line 11)
- `.github/workflows/test.yml` (line 11)
- `.github/workflows/integration.yml` (line 18)
- `.github/workflows/nightly.yml` (lines 21, 54)
- `.github/workflows/publish.yml` (lines 22, 25)

`publish.yml`'s job-level `id-token: write` (JSR OIDC) and `contents: read` (npm) remain at job scope so the workflow-level fallback doesn't widen them.

## Incomplete sanitization (high x2)

Rule: `js/incomplete-sanitization`
- `src/query/helpers.ts:33` (`quoteValue`)
- `src/types/operators.ts:33` (`quoteValue`)

The previous `value.replace(/'/g, "\\'")` only escaped `'`. An input like `a\'; SELECT * FROM users; --` would emit `'a\\'; SELECT * FROM users; --'`, which a SurrealQL parser reads as `'a\'` (backslash escaped) followed by raw query text -- classic quote smuggling.

Fix: escape `\` first, then `'`:
```ts
const escaped = value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
```

Added regression tests in `src/test/helpers.test.ts` and `src/test/operators.test.ts` asserting the previously-vulnerable input round-trips correctly.

## Validation
- `deno fmt --check` clean
- `deno lint` clean
- `deno check mod.ts` clean
- `deno test src/test/helpers.test.ts src/test/operators.test.ts` -> 5 passed (88 steps)