### PR TITLE
chore(ci): group dependabot updates + auto-merge patches

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,42 @@
+name: Dependabot Auto-merge
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for required checks
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor' ||
+          steps.meta.outputs.package-ecosystem == 'github_actions'
+        uses: lewagon/wait-on-check-action@v1.4.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          running-workflow-name: auto-merge
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+          allowed-conclusions: success,skipped
+
+      - name: Approve + auto-merge (patches, minors, GH Actions)
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor' ||
+          steps.meta.outputs.package-ecosystem == 'github_actions'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds an auto-merge GitHub Actions workflow that approves and merges dependabot PRs after CI passes for:

- patch updates (any ecosystem)
- minor updates (any ecosystem)
- github-actions updates (any `update-type`, including major)

Major bumps for the language ecosystem(s) still require human review.

## Why

PR backlogs were sitting open for weeks; trying to admin-merge them in parallel caused `Base branch was modified` races as each merge invalidated the others. Grouping (already configured in `.github/dependabot.yml`) reduces volume; this workflow keeps the queue empty automatically.

## Requirements to take effect

- `Allow auto-merge` enabled in `Settings -> General` (repo-level toggle).
- A branch-protection rule on `main` with at least one required status check.

If neither is set, `gh pr merge --auto` will fail and the workflow run will error -- harmless, but auto-merge will not actually happen until those are enabled.

## Test plan

- [ ] Merge this PR (admin-merge OK -- pure CI plumbing).
- [ ] Confirm `Allow auto-merge` is on.
- [ ] Confirm branch-protection has at least one required check.
- [ ] Wait for next dependabot weekly run (Monday 06:00 America/Anchorage); confirm a patch/minor PR is auto-approved + merged after CI.
