### PR TITLE
chore(ci): drop version-type filter from dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,10 +17,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Wait for required checks
-        if: |
-          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
-          steps.meta.outputs.update-type == 'version-update:semver-minor' ||
-          steps.meta.outputs.package-ecosystem == 'github_actions'
         uses: lewagon/wait-on-check-action@v1.4.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -29,11 +25,7 @@ jobs:
           wait-interval: 30
           allowed-conclusions: success,skipped
 
-      - name: Approve + auto-merge (patches, minors, GH Actions)
-        if: |
-          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
-          steps.meta.outputs.update-type == 'version-update:semver-minor' ||
-          steps.meta.outputs.package-ecosystem == 'github_actions'
+      - name: Approve + auto-merge
         run: |
           gh pr review --approve "$PR_URL"
           gh pr merge --auto --squash --delete-branch "$PR_URL"


### PR DESCRIPTION
Drops the `version-update:semver-patch`/`semver-minor`/`github_actions` ecosystem filter from the dependabot auto-merge workflow. CI is the gate now: if tests pass after a bump (including major), auto-merge proceeds.

The previous policy left major bumps stranded as manual work. Since the test suite already exercises the upgraded dependency on every PR, a green CI run is sufficient signal that the bump is safe.

The workflow still gates on `github.actor == 'dependabot[bot]'`, so this only affects dependabot PRs.