### PR TITLE
fix(ci): switch CI to aur0 self-hosted runner; drop macOS from push/PR

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   audit:
     name: npm audit (npm: specifiers from deno.json)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   code_quality:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     strategy:
       matrix:
         deno-version: [v2.x]

--- a/.github/workflows/dep-review.yml
+++ b/.github/workflows/dep-review.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   dep-review:
     name: Dependency Review
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   auto-merge:
     if: github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     steps:
       - name: Get PR metadata
         id: meta

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     steps:
       - uses: actions/checkout@v5
 
@@ -39,7 +39,7 @@ jobs:
           path: site/
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     needs: build
     environment:
       name: github-pages

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,8 +1,8 @@
 name: Integration Tests
 
 # Cost-conscious surface: manual-only. Integration spins a SurrealDB
-# container per run; expensive when fired on every push. Trigger from
-# the Actions UI when integration sign-off is needed.
+# container per run; trigger from the Actions UI when integration
+# sign-off is needed.
 on:
   workflow_dispatch:
 
@@ -18,7 +18,7 @@ env:
 
 jobs:
   integration:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     steps:
       - uses: actions/checkout@v5
       - name: Setup Deno

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,8 @@ jobs:
   # Unit + type checks across the full OS x Deno matrix. macOS runners
   # don't have Docker pre-installed on GitHub-hosted runners, so the
   # integration tests (which spin up a SurrealDB container) only run
-  # in the separate integration job below.
+  # in the separate integration job below. macOS coverage is retained
+  # here as the cross-platform safety net for what we dropped from PR/push.
   sanity:
     name: Sanity (${{ matrix.os }} / Deno ${{ matrix.deno }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
     if: |
       github.event_name == 'release' ||
       (github.event_name == 'workflow_dispatch' && (inputs.target == 'jsr' || inputs.target == 'both'))
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     permissions:
       contents: read
       id-token: write
@@ -50,7 +50,7 @@ jobs:
     if: |
       (github.event_name == 'release' && !github.event.release.prerelease) ||
       (github.event_name == 'workflow_dispatch' && (inputs.target == 'npm' || inputs.target == 'both'))
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     environment: ${{ github.event_name == 'release' && 'publish' || '' }}
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     strategy:
       matrix:
         deno-version: [v2.x]


### PR DESCRIPTION
Stops the GitHub-hosted minute bleed by routing every push/PR-triggered job to the org's `[self-hosted, aur0]` runner. macOS coverage stays in `nightly.yml`.

## Per-workflow changes

| Workflow | Before | After |
|---|---|---|
| `check.yml` (reusable) | `runs-on: ubuntu-latest` | `runs-on: [self-hosted, aur0]` |
| `test.yml` (reusable) | `runs-on: ubuntu-latest` | `runs-on: [self-hosted, aur0]` |
| `audit.yml` | `runs-on: ubuntu-latest` (workflow_dispatch only) | `runs-on: [self-hosted, aur0]` |
| `dep-review.yml` | `runs-on: ubuntu-latest` | `runs-on: [self-hosted, aur0]` |
| `dependabot-auto-merge.yml` | `runs-on: ubuntu-latest` | `runs-on: [self-hosted, aur0]` |
| `docs.yml` | `runs-on: ubuntu-latest` (build + deploy) | `runs-on: [self-hosted, aur0]` |
| `integration.yml` | `runs-on: ubuntu-latest` (workflow_dispatch only) | `runs-on: [self-hosted, aur0]` |
| `nightly.yml` | `sanity` matrix runs `os: [ubuntu-latest, macos-latest]`; `integration` on `ubuntu-latest` | Unchanged — this is the nightly cross-platform safety net |
| `publish.yml` | `runs-on: ubuntu-latest` (publish-jsr/publish-npm) | `runs-on: [self-hosted, aur0]` |

## Untouched

- `nightly.yml` retains its full ubuntu+macos matrix because that's the off-hours coverage the dropped PR-time macOS jobs would otherwise leave bare.
- `ci.yml` is a reusable-workflow caller (no `runs-on`); it's already cost-conscious (PR-only).

## Test plan

- [ ] aur0 picks up `check` + `test` reusable jobs from `ci.yml`
- [ ] `dep-review.yml` still annotates PRs
- [ ] manual-only `audit.yml` and `integration.yml` dispatch successfully on aur0