### PR TITLE
fix(ci): generate lockfile before npm audit in audit.yml

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -70,5 +70,10 @@ jobs:
           console.log(JSON.stringify(pkg, null, 2))
           EOF
 
+      - name: Generate lockfile for synthesized package.json
+        # `npm audit` requires an existing lockfile (ENOLOCK otherwise).
+        # We never commit it -- it lives only for the duration of the job.
+        run: npm install --package-lock-only --omit=dev
+
       - name: Run npm audit
         run: npm audit --audit-level=moderate --omit=dev

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   audit:
-    name: npm audit (npm: specifiers from deno.json)
+    name: "npm audit (npm: specifiers from deno.json)"
     runs-on: [self-hosted, aur0]
     steps:
       - uses: actions/checkout@v5
@@ -35,7 +35,7 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Synthesize package.json from deno.json npm: imports
+      - name: "Synthesize package.json from deno.json npm: imports"
         run: |
           node <<'EOF'
           const fs = require('node:fs')


### PR DESCRIPTION
## Summary

- The audit.yml workflow has been silently startup-failing on every push since aur0 migration (more accurately: since it was first added) because the YAML is invalid: two `name:` values contain unquoted `npm:` substrings, and the colon-space makes a YAML scanner treat the value as a nested mapping. GitHub Actions cannot parse the file, records a phantom failure (zero jobs, zero billable time, no logs), uses the file path as the workflow name, and rejects `workflow_dispatch` calls with "Workflow does not have workflow_dispatch trigger". This is **not** an aur0 tooling problem.
- Quote both `name:` strings so the YAML parses cleanly.
- Also add `npm install --package-lock-only --omit=dev` between synthesis and audit, because once the YAML parses the audit step would have hit ENOLOCK on the synthesized `package.json` (no committed lockfile by design).

## Local repro evidence

YAML invalid:
```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/audit.yml'))"
yaml.scanner.ScannerError: mapping values are not allowed here
  in ".github/workflows/audit.yml", line 28, column 25
```

GitHub confirms the file is unparseable:
```
$ gh api repos/Oneiriq/surql/actions/workflows/263016540 --jq .name
.github/workflows/audit.yml      # should be "Security Audit"
$ gh workflow run audit.yml -R Oneiriq/surql --ref main
HTTP 422: Workflow does not have 'workflow_dispatch' trigger
```

ENOLOCK that would have hit once YAML was fixed (Mac, node 24.14):
```
$ npm audit --audit-level=moderate --omit=dev
npm error code ENOLOCK
npm error audit This command requires an existing lockfile.
EXIT: 1
```

After both fixes:
```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/audit.yml'))"
(parses cleanly)
$ npm install --package-lock-only --omit=dev && npm audit --audit-level=moderate --omit=dev
found 0 vulnerabilities
EXIT: 0
```

## Test plan

- [x] YAML parses with PyYAML safe_load
- [x] `npm i --package-lock-only --omit=dev` then `npm audit` exits 0 on the synthesized package.json
- [ ] Post-merge: `gh workflow run audit.yml -R Oneiriq/surql --ref main` succeeds (registration is rebuilt)