### PR TITLE
chore(release): v1.3.5 — docs fixes + CI hardening

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,11 @@ env:
 
 jobs:
   code_quality:
-    runs-on: [self-hosted, aur0]
+    # Reusable workflow — inherits the caller's trigger context. When
+    # called from ci.yml on a fork PR, route to ubuntu-latest so PR
+    # code never executes on aur0. Other callers (release.yml,
+    # workflow_dispatch) see null `pull_request` and pick aur0.
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJSON('["self-hosted", "aur0"]') }}
     strategy:
       matrix:
         deno-version: [v2.x]

--- a/.github/workflows/dep-review.yml
+++ b/.github/workflows/dep-review.yml
@@ -16,7 +16,11 @@ env:
 jobs:
   dep-review:
     name: Dependency Review
-    runs-on: [self-hosted, aur0]
+    # aur0 self-hosted for same-repo PRs (Oneiriq members); fork PRs
+    # fall back to ubuntu-latest so untrusted PR code never executes
+    # on the org's internal runner. github.event.pull_request is null
+    # on non-PR events → expression picks aur0 by default.
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJSON('["self-hosted", "aur0"]') }}
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,10 @@ name: Deploy Documentation
 on:
   push:
     branches: [main]
+  # Run the strict build on PRs too, so broken links / nav are caught
+  # before merge instead of failing silently in the post-merge deploy.
+  pull_request:
+    branches: [main, 'release/**']
   workflow_dispatch:
 
 permissions:
@@ -39,6 +43,8 @@ jobs:
           path: site/
 
   deploy:
+    # Deploy only on push to main / manual dispatch — never for PR builds.
+    if: github.event_name != 'pull_request'
     runs-on: [self-hosted, aur0]
     needs: build
     environment:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,10 @@ env:
 
 jobs:
   build:
-    runs-on: [self-hosted, aur0]
+    # Build runs for both push to main AND fork PRs (link/nav check).
+    # Same-repo PRs and push run on aur0; fork PRs fall back to
+    # ubuntu-latest so untrusted PR code never executes on aur0.
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJSON('["self-hosted", "aur0"]') }}
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,11 @@ env:
 
 jobs:
   test:
-    runs-on: [self-hosted, aur0]
+    # Reusable workflow — inherits the caller's trigger context. When
+    # called from ci.yml on a fork PR, route to ubuntu-latest so the
+    # `deno test -A` invocation (which runs fork-controlled code with
+    # full permissions) never executes on aur0.
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJSON('["self-hosted", "aur0"]') }}
     strategy:
       matrix:
         deno-version: [v2.x]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,48 @@
 # Changelog
 
+## [1.3.5] - 2026-05-15
+
+### Fixed
+
+- **Docs**: corrected the "Buffered `BEGIN` / `COMMIT`" warning on the v3 Patterns page — the `Found COMMIT TRANSACTION, but ...` code span was immediately followed by the sentence period, rendering a stray trailing `....`.
+
+### Changed
+
+- **Docs**: replaced informal "wave" phrasing with neutral wording across `docs/query-ux.md`, `docs/migration.md`, and the changelog.
+- **CI**: the documentation workflow now runs `mkdocs build --strict` on pull requests, so broken links and nav errors are caught before merge instead of only in the post-merge deploy.
+- **CI**: closed open code-scanning alerts, added a label-driven Dependabot auto-merge workflow, moved CI/audit onto the `aur0` self-hosted runner, and added the scheduled `deno-update` workflow (#49–#54).
+
+### Housekeeping
+
+- Version bumped to `1.3.5` in `deno.json`.
+
+---
+
+## [1.3.4] - 2026-04-30
+
+### Fixed
+
+- **Publish**: corrected the npm package license metadata and skipped a redundant dnt typecheck (#48).
+
+---
+
+## [1.3.3] - 2026-04-30
+
+### Changed
+
+- **License**: relicensed to Apache-2.0 with a `NOTICE` file (#46).
+
+### Housekeeping
+
+- Trimmed auto-trigger workflows and bumped to `1.3.3` (#47).
+
+---
+
 ## [1.3.2] - 2026-04-19
 
 ### Changed
 
-- **Docs refresh** (#37): documented every wave that landed since v1.0.0. New pages: `docs/v3-patterns.md` (buffered BEGIN/COMMIT, `IF NOT EXISTS` emitter, unrolled graph depth), `docs/query-ux.md` (`typeRecord` / `typeThing`, function factories, `FunctionValueExpression`, `extractMany` / `hasResult`, `aggregateRecords`, `updateRecord` / `getRecord` overloads), `docs/cli.md` (`surql migrate|schema|db|orchestrate|settings` reference), `docs/migration.md` (upgrade notes v1.1.0 → v1.2.0 → v1.3.x). README refreshed with first-class helper examples (`typeRecord`, `timeNow`, `aggregateRecords`, `surql` CLI). mkdocs nav extended; `mkdocs build --strict` stays clean.
+- **Docs refresh** (#37): documented every release that landed since v1.0.0. New pages: `docs/v3-patterns.md` (buffered BEGIN/COMMIT, `IF NOT EXISTS` emitter, unrolled graph depth), `docs/query-ux.md` (`typeRecord` / `typeThing`, function factories, `FunctionValueExpression`, `extractMany` / `hasResult`, `aggregateRecords`, `updateRecord` / `getRecord` overloads), `docs/cli.md` (`surql migrate|schema|db|orchestrate|settings` reference), `docs/migration.md` (upgrade notes v1.1.0 → v1.2.0 → v1.3.x). README refreshed with first-class helper examples (`typeRecord`, `timeNow`, `aggregateRecords`, `surql` CLI). mkdocs nav extended; `mkdocs build --strict` stays clean.
 
 ### Housekeeping
 
@@ -22,7 +60,7 @@
 
 ## [1.3.0] - 2026-04-19
 
-### Added — Query-UX wave (#29)
+### Added — Query UX (#29)
 
 - **`typeRecord(table, id?)` / `typeThing(table, id?)`** (#6): first-class SurrealDB v3 record references. `typeThing` is the parity alias for surql-py/rs/go. Emits `type::record('table:id')` (v3-valid; v3 dropped `type::thing`).
 - **Function factories** (#7): `countIf`, `mathAbs`/`mathCeil`/`mathFloor`/`mathRound`, `stringLen`/`stringLower`/`stringUpper`/`stringConcat`. Short-form aliases (`abs_`, `ceil`, `floor`, `round_`, `upper`, `lower`, `concat`, `stringLength`) retained for pre-1.3.0 callers.
@@ -39,7 +77,7 @@
 
 ## [1.2.0] - 2026-04-19
 
-### Added — Parity wave (#19, #21, #24)
+### Added — Parity (#19, #21, #24)
 
 - **Structured schema parser** (#19): `parseDbInfo`, `parseTableInfo`, `parseFields`, `parseIndexes`, `parseEvents`, `parseAccess`, `parseEdgeInfo`, plus `SchemaParseError`. Full port of the surql-py/surql-rs/surql-go `DEFINE` parser (HNSW index, JWT URL/duration variants, lookbehind edge cases).
 - **Layered settings loader** (`loadSettings`, `getSettings`, `clearSettingsCache`, `getDbConfig`, `getMigrationPath`): reads env vars, `.env`, `surql.yaml`, and `surql.toml` with precedence matching the py/rs/go ports.

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "lock": true,
   "name": "@oneiriq/surql",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "license": "Apache-2.0",
   "exports": {
     ".": "./mod.ts",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,10 +1,48 @@
 # Changelog
 
+## [1.3.5] - 2026-05-15
+
+### Fixed
+
+- **Docs**: corrected the "Buffered `BEGIN` / `COMMIT`" warning on the v3 Patterns page — the `Found COMMIT TRANSACTION, but ...` code span was immediately followed by the sentence period, rendering a stray trailing `....`.
+
+### Changed
+
+- **Docs**: replaced informal "wave" phrasing with neutral wording across `docs/query-ux.md`, `docs/migration.md`, and the changelog.
+- **CI**: the documentation workflow now runs `mkdocs build --strict` on pull requests, so broken links and nav errors are caught before merge instead of only in the post-merge deploy.
+- **CI**: closed open code-scanning alerts, added a label-driven Dependabot auto-merge workflow, moved CI/audit onto the `aur0` self-hosted runner, and added the scheduled `deno-update` workflow (#49–#54).
+
+### Housekeeping
+
+- Version bumped to `1.3.5` in `deno.json`.
+
+---
+
+## [1.3.4] - 2026-04-30
+
+### Fixed
+
+- **Publish**: corrected the npm package license metadata and skipped a redundant dnt typecheck (#48).
+
+---
+
+## [1.3.3] - 2026-04-30
+
+### Changed
+
+- **License**: relicensed to Apache-2.0 with a `NOTICE` file (#46).
+
+### Housekeeping
+
+- Trimmed auto-trigger workflows and bumped to `1.3.3` (#47).
+
+---
+
 ## [1.3.2] - 2026-04-19
 
 ### Changed
 
-- **Docs refresh** (#37): documented every wave that landed since v1.0.0. New pages: `docs/v3-patterns.md` (buffered BEGIN/COMMIT, `IF NOT EXISTS` emitter, unrolled graph depth), `docs/query-ux.md` (`typeRecord` / `typeThing`, function factories, `FunctionValueExpression`, `extractMany` / `hasResult`, `aggregateRecords`, `updateRecord` / `getRecord` overloads), `docs/cli.md` (`surql migrate|schema|db|orchestrate|settings` reference), `docs/migration.md` (upgrade notes v1.1.0 → v1.2.0 → v1.3.x). README refreshed with first-class helper examples (`typeRecord`, `timeNow`, `aggregateRecords`, `surql` CLI). mkdocs nav extended; `mkdocs build --strict` stays clean.
+- **Docs refresh** (#37): documented every release that landed since v1.0.0. New pages: `docs/v3-patterns.md` (buffered BEGIN/COMMIT, `IF NOT EXISTS` emitter, unrolled graph depth), `docs/query-ux.md` (`typeRecord` / `typeThing`, function factories, `FunctionValueExpression`, `extractMany` / `hasResult`, `aggregateRecords`, `updateRecord` / `getRecord` overloads), `docs/cli.md` (`surql migrate|schema|db|orchestrate|settings` reference), `docs/migration.md` (upgrade notes v1.1.0 → v1.2.0 → v1.3.x). README refreshed with first-class helper examples (`typeRecord`, `timeNow`, `aggregateRecords`, `surql` CLI). mkdocs nav extended; `mkdocs build --strict` stays clean.
 
 ### Housekeeping
 
@@ -22,7 +60,7 @@
 
 ## [1.3.0] - 2026-04-19
 
-### Added — Query-UX wave (#29)
+### Added — Query UX (#29)
 
 - **`typeRecord(table, id?)` / `typeThing(table, id?)`** (#6): first-class SurrealDB v3 record references. `typeThing` is the parity alias for surql-py/rs/go. Emits `type::record('table:id')` (v3-valid; v3 dropped `type::thing`).
 - **Function factories** (#7): `countIf`, `mathAbs`/`mathCeil`/`mathFloor`/`mathRound`, `stringLen`/`stringLower`/`stringUpper`/`stringConcat`. Short-form aliases (`abs_`, `ceil`, `floor`, `round_`, `upper`, `lower`, `concat`, `stringLength`) retained for pre-1.3.0 callers.
@@ -39,7 +77,7 @@
 
 ## [1.2.0] - 2026-04-19
 
-### Added — Parity wave (#19, #21, #24)
+### Added — Parity (#19, #21, #24)
 
 - **Structured schema parser** (#19): `parseDbInfo`, `parseTableInfo`, `parseFields`, `parseIndexes`, `parseEvents`, `parseAccess`, `parseEdgeInfo`, plus `SchemaParseError`. Full port of the surql-py/surql-rs/surql-go `DEFINE` parser (HNSW index, JWT URL/duration variants, lookbehind edge cases).
 - **Layered settings loader** (`loadSettings`, `getSettings`, `clearSettingsCache`, `getDbConfig`, `getMigrationPath`): reads env vars, `.env`, `surql.yaml`, and `surql.toml` with precedence matching the py/rs/go ports.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -51,7 +51,7 @@ All additive; the old APIs keep working.
 - **Schema drift hooks** (`checkSchemaDrift`, `generatePrecommitConfig`, `watchSchema`) plug into git pre-commit and live dev loops.
 - **`surql` CLI** (`deno task cli …` or `jsr:@oneiriq/surql/cli`). See the [CLI reference](cli.md).
 
-## v1.2.0 → v1.3.0 (Query-UX wave)
+## v1.2.0 → v1.3.0 (Query UX)
 
 ### Adopt `typeRecord` / `typeThing` for record references
 
@@ -127,7 +127,7 @@ CI-only fix: `src/test/integration*.test.ts` is now excluded from the publish-ti
 
 ## v1.3.1 → v1.3.2
 
-Documentation refresh only. No code changes. The rendered site now covers every wave that landed since v1.0.0 (v3 patterns, query UX, CLI, upgrade notes). `deno.json` is bumped to `1.3.2` so the refreshed docs publish alongside the version.
+Documentation refresh only. No code changes. The rendered site now covers every release that landed since v1.0.0 (v3 patterns, query UX, CLI, upgrade notes). `deno.json` is bumped to `1.3.2` so the refreshed docs publish alongside the version.
 
 ## Developer experience — enable the pre-push hook
 

--- a/docs/query-ux.md
+++ b/docs/query-ux.md
@@ -1,6 +1,6 @@
 # Query UX
 
-The v1.3.x query-UX wave fills in first-class helpers for the patterns callers were previously reaching into `raw()` / `surqlFn()` for. This page shows the before/after for each helper.
+The v1.3.x query-UX release fills in first-class helpers for the patterns callers were previously reaching into `raw()` / `surqlFn()` for. This page shows the before/after for each helper.
 
 ## `typeRecord` / `typeThing` references
 

--- a/docs/v3-patterns.md
+++ b/docs/v3-patterns.md
@@ -19,7 +19,7 @@ await tx.commit() // issues BEGIN TRANSACTION; ...; COMMIT TRANSACTION; in one R
 ```
 
 !!! warning "Do not stream statements"
-    Splitting `BEGIN TRANSACTION` and `COMMIT TRANSACTION` across separate `db.query()` calls worked on v1/v2 but fails on v3 with `Found COMMIT TRANSACTION, but ...`.
+    Splitting `BEGIN TRANSACTION` and `COMMIT TRANSACTION` across separate `db.query()` calls worked on v1/v2 but is rejected on v3 with a `Found COMMIT TRANSACTION, but ...` parse error.
 
 `Transaction.cancel()` discards the buffer client-side without ever contacting the server. `Transaction` also implements `Symbol.asyncDispose` so `await using tx = transaction(db)` auto-cancels if the block exits without committing.
 


### PR DESCRIPTION
## Summary

Release **v1.3.5** — documentation fixes and CI hardening. No library code changes.

### Fixed
- **v3 Patterns page**: the "Buffered `BEGIN` / `COMMIT`" warning rendered a stray trailing `....` because the `Found COMMIT TRANSACTION, but ...` code span was immediately followed by the sentence period. Reworded so the ellipsis reads cleanly.

### Changed
- Removed informal "wave" phrasing from `docs/query-ux.md`, `docs/migration.md`, and the changelog in favour of neutral wording.
- Backfilled the missing **1.3.3** and **1.3.4** changelog entries (both were tagged but never documented).
- `docs.yml` now runs `mkdocs build --strict` on pull requests (deploy still only on push to `main`), so broken links / nav errors are caught before merge instead of failing silently post-merge.

### Verified
- `mkdocs build --strict` passes.
- `deno fmt --check`, `deno lint`, `deno check mod.ts` all pass.
- Nightly workflow was already `workflow_dispatch`-only; CI was already PR-only — no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)