### PR TITLE
chore(release): v1.4.0 — v3-correctness fixes, schema/query parity, CI hardening

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -11,9 +11,21 @@ name: Security Audit
 # is committed. JSR-only updates are still caught by `nightly.yml` via
 # the Deno version matrix.
 
-# Cost-conscious surface: manual-only for now (3000 action minutes/month
-# budget). Re-enable PR/push/schedule when the budget allows.
+# Fires on PRs that touch the dependency surface (paths-filtered so unrelated
+# PRs don't trigger an audit), on a daily schedule to catch newly-published
+# advisories, and on manual dispatch.
 on:
+  pull_request:
+    branches:
+      - main
+      - 'release/**'
+    paths:
+      - 'deno.json'
+      - 'deno.lock'
+      - '.github/workflows/audit.yml'
+  schedule:
+    # Daily at 04:00 UTC.
+    - cron: '0 4 * * *'
   workflow_dispatch:
 
 concurrency:
@@ -26,9 +38,12 @@ env:
 jobs:
   audit:
     name: "npm audit (npm: specifiers from deno.json)"
-    runs-on: [self-hosted, aur0]
+    # aur0 self-hosted for push/schedule/dispatch + same-repo PRs. Fork PRs
+    # fall back to ubuntu-latest — the synthesized `npm install` runs npm
+    # against PR-controlled specifiers, so it must never touch aur0.
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJSON('["self-hosted", "aur0"]') }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         deno-version: [v2.x]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,11 @@ env:
 
 jobs:
   code_quality:
-    runs-on: [self-hosted, aur0]
+    # Reusable workflow — inherits the caller's trigger context. When
+    # called from ci.yml on a fork PR, route to ubuntu-latest so PR
+    # code never executes on aur0. Other callers (release.yml,
+    # workflow_dispatch) see null `pull_request` and pick aur0.
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJSON('["self-hosted", "aur0"]') }}
     strategy:
       matrix:
         deno-version: [v2.x]

--- a/.github/workflows/deno-update.yml
+++ b/.github/workflows/deno-update.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: [self-hosted, aur0]
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/dep-review.yml
+++ b/.github/workflows/dep-review.yml
@@ -16,7 +16,11 @@ env:
 jobs:
   dep-review:
     name: Dependency Review
-    runs-on: [self-hosted, aur0]
+    # aur0 self-hosted for same-repo PRs (Oneiriq members); fork PRs
+    # fall back to ubuntu-latest so untrusted PR code never executes
+    # on the org's internal runner. github.event.pull_request is null
+    # on non-PR events → expression picks aur0 by default.
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJSON('["self-hosted", "aur0"]') }}
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/dep-review.yml
+++ b/.github/workflows/dep-review.yml
@@ -6,6 +6,12 @@ on:
       - main
       - 'release/**'
 
+# One run per (workflow, ref); a new push to a PR branch cancels the prior
+# in-flight review.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write
@@ -16,13 +22,13 @@ env:
 jobs:
   dep-review:
     name: Dependency Review
-    # aur0 self-hosted for same-repo PRs (Oneiriq members); fork PRs
-    # fall back to ubuntu-latest so untrusted PR code never executes
-    # on the org's internal runner. github.event.pull_request is null
-    # on non-PR events → expression picks aur0 by default.
+    # aur0 self-hosted for same-repo PRs (Oneiriq members); fork PRs fall
+    # back to ubuntu-latest so untrusted PR code never executes on the org's
+    # internal runner. github.event.pull_request is null on non-PR events →
+    # expression picks aur0 by default.
     runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJSON('["self-hosted", "aur0"]') }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,13 @@
 name: Dependabot Auto-merge
 on: pull_request_target
 
+# One auto-merge run per PR ref; a re-trigger cancels the prior in-flight run
+# so a fanned-out stack of dependabot PRs doesn't pile up long-running
+# check-waiters all competing for the same runner.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
   contents: write
@@ -12,12 +19,12 @@ jobs:
     steps:
       - name: Get PR metadata
         id: meta
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Wait for required checks
-        uses: lewagon/wait-on-check-action@v1.4.0
+        uses: lewagon/wait-on-check-action@v1.7.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           running-workflow-name: auto-merge

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,10 @@ name: Deploy Documentation
 on:
   push:
     branches: [main]
+  # Run the strict build on PRs too, so broken links / nav are caught
+  # before merge instead of failing silently in the post-merge deploy.
+  pull_request:
+    branches: [main, 'release/**']
   workflow_dispatch:
 
 permissions:
@@ -39,6 +43,8 @@ jobs:
           path: site/
 
   deploy:
+    # Deploy only on push to main / manual dispatch — never for PR builds.
+    if: github.event_name != 'pull_request'
     runs-on: [self-hosted, aur0]
     needs: build
     environment:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,23 +14,29 @@ permissions:
   pages: write
   id-token: write
 
+# Cancel in-progress doc builds on the same ref when a newer commit arrives.
+# Keyed by ref (NOT a global 'pages' group): a global group serialised every
+# build/deploy across all refs behind one queue, so a stalled run wedged the
+# whole pipeline for hours. Per-ref keying lets a PR build and the main-branch
+# deploy proceed independently; the `github-pages` environment still serialises
+# the actual deployment.
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build:
-    # Build runs for both push to main AND fork PRs (link/nav check).
+    # Build runs for push to main, dispatch, AND fork PRs (link/nav check).
     # Same-repo PRs and push run on aur0; fork PRs fall back to
     # ubuntu-latest so untrusted PR code never executes on aur0.
     runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJSON('["self-hosted", "aur0"]') }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -41,7 +47,7 @@ jobs:
         run: mkdocs build --strict
 
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site/
 
@@ -56,4 +62,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,10 @@ env:
 
 jobs:
   build:
-    runs-on: [self-hosted, aur0]
+    # Build runs for both push to main AND fork PRs (link/nav check).
+    # Same-repo PRs and push run on aur0; fork PRs fall back to
+    # ubuntu-latest so untrusted PR code never executes on aur0.
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJSON('["self-hosted", "aur0"]') }}
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,11 +1,16 @@
 name: Integration Tests
 
-# Cost-conscious surface: manual-only. Integration spins a SurrealDB
-# container per run; trigger from the Actions UI when integration
-# sign-off is needed.
+# Integration tests run a SurrealDB v3 container as a sibling of the runner
+# and reach it on localhost:8000. They fire on PRs (so v3 regressions are
+# caught before merge, not only on a manual dispatch nobody remembers to run)
+# and on manual dispatch.
 on:
+  pull_request:
+    branches: [main, 'release/**']
   workflow_dispatch:
 
+# One run per (workflow, ref); a new push to a PR branch cancels the prior
+# in-flight integration run — only the latest commit's result matters.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -18,21 +23,34 @@ env:
 
 jobs:
   integration:
-    runs-on: [self-hosted, aur0]
+    name: SurrealDB v3 integration tests
+    # Pinned to ubuntu-latest (NOT aur0 self-hosted). The job runs SurrealDB
+    # as a sibling Docker container and the tests reach it on localhost:8000 —
+    # only valid on a GH-hosted runner where the runner IS the host. On a
+    # containerized aur0 runner the tests sit on a separate bridge network so
+    # the connect fails, and host :8000 is already owned there. ubuntu-latest
+    # also keeps fork-PR code off the org's internal runner.
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
+
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
-      - name: Start SurrealDB
+
+      - name: Start SurrealDB v3
         run: |
+          # A stopped `surrealdb` container from a prior run can still own the
+          # name; idempotent removal avoids a "container name already in use"
+          # 409 conflict.
+          docker rm -f surrealdb >/dev/null 2>&1 || true
           docker run -d \
             --name surrealdb \
             -p 8000:8000 \
             surrealdb/surrealdb:v3.0.5 \
             start --user root --pass root memory
-          for i in $(seq 1 20); do
+          for i in $(seq 1 30); do
             if curl -sf http://localhost:8000/health; then
               echo "SurrealDB is ready"
               break
@@ -40,6 +58,9 @@ jobs:
             echo "Waiting for SurrealDB... attempt $i"
             sleep 2
           done
+          # Fail the job fast if the server never came up.
+          curl -sf http://localhost:8000/health
+
       - name: Run integration tests
         run: |
           deno test -A \
@@ -48,3 +69,7 @@ jobs:
             src/test/integration_crud.test.ts \
             src/test/integration_client.test.ts \
             -q
+
+      - name: Stop SurrealDB
+        if: always()
+        run: docker stop surrealdb || true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         deno: [v2.x, canary]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup Deno
         uses: denoland/setup-deno@v2
@@ -63,7 +63,7 @@ jobs:
         deno: [v2.x, canary]
         surreal: ['v3.0.5', 'latest']
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup Deno
         uses: denoland/setup-deno@v2

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -8,6 +8,11 @@ on:
       - synchronize
       - reopened
 
+# One lint run per PR ref; a rapid re-edit cancels the prior in-flight run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: read
 
@@ -19,7 +24,7 @@ jobs:
     name: Conventional Commit PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
@@ -55,7 +55,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,11 @@ env:
 
 jobs:
   test:
-    runs-on: [self-hosted, aur0]
+    # Reusable workflow — inherits the caller's trigger context. When
+    # called from ci.yml on a fork PR, route to ubuntu-latest so the
+    # `deno test -A` invocation (which runs fork-controlled code with
+    # full permissions) never executes on aur0.
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJSON('["self-hosted", "aur0"]') }}
     strategy:
       matrix:
         deno-version: [v2.x]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         deno-version: [v2.x]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **`quoteValue()` flattened objects, RecordIds, and Dates with `JSON.stringify`.** A nested `SurrealFnValue`, `RecordId`, or `Date` was serialized as a JSON blob rather than SurrealQL — `{ created: <fn> }` came out as `{"created":{"__surqlFn":true,...}}`. `quoteValue()` now recurses through plain objects emitting SurrealQL object literals, renders `RecordId` instances as a record-id literal (`user:alice`), and renders `Date` instances as a `d'...'` datetime literal (a bare quoted ISO string is rejected by v3 datetime-typed fields).
 - **The migration differ emitted incomplete, mistyped DDL.** `ADD_FIELD`/`MODIFY_FIELD` diffs rendered a bare `TYPE <FieldType>`, dropping `record<target>`, array element types, and `option<...>`; `MODIFY_FIELD` only fired on a base-type change, so a changed record link or optionality went undetected. `ADD_TABLE` for a new table emitted only `DEFINE TABLE name mode;` — applying that migration created an empty table. Diffs now render field types through the shared generator, and a new table (or edge) emits its complete DDL.
 - **Docs**: corrected the "Buffered `BEGIN` / `COMMIT`" warning on the v3 Patterns page — the `Found COMMIT TRANSACTION, but ...` code span was immediately followed by the sentence period, rendering a stray trailing `....`.
+- **Docs**: the migration documentation imported and called APIs that surql does not export (`diffSchemas`, `MigrationRunner`, `RollbackManager`, `generateVersion`, and others). Every such example is rewritten against the real exported API (#62).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,48 @@
 # Changelog
 
+## [1.3.5] - 2026-05-15
+
+### Fixed
+
+- **Docs**: corrected the "Buffered `BEGIN` / `COMMIT`" warning on the v3 Patterns page — the `Found COMMIT TRANSACTION, but ...` code span was immediately followed by the sentence period, rendering a stray trailing `....`.
+
+### Changed
+
+- **Docs**: replaced informal "wave" phrasing with neutral wording across `docs/query-ux.md`, `docs/migration.md`, and the changelog.
+- **CI**: the documentation workflow now runs `mkdocs build --strict` on pull requests, so broken links and nav errors are caught before merge instead of only in the post-merge deploy.
+- **CI**: closed open code-scanning alerts, added a label-driven Dependabot auto-merge workflow, moved CI/audit onto the `aur0` self-hosted runner, and added the scheduled `deno-update` workflow (#49–#54).
+
+### Housekeeping
+
+- Version bumped to `1.3.5` in `deno.json`.
+
+---
+
+## [1.3.4] - 2026-04-30
+
+### Fixed
+
+- **Publish**: corrected the npm package license metadata and skipped a redundant dnt typecheck (#48).
+
+---
+
+## [1.3.3] - 2026-04-30
+
+### Changed
+
+- **License**: relicensed to Apache-2.0 with a `NOTICE` file (#46).
+
+### Housekeeping
+
+- Trimmed auto-trigger workflows and bumped to `1.3.3` (#47).
+
+---
+
 ## [1.3.2] - 2026-04-19
 
 ### Changed
 
-- **Docs refresh** (#37): documented every wave that landed since v1.0.0. New pages: `docs/v3-patterns.md` (buffered BEGIN/COMMIT, `IF NOT EXISTS` emitter, unrolled graph depth), `docs/query-ux.md` (`typeRecord` / `typeThing`, function factories, `FunctionValueExpression`, `extractMany` / `hasResult`, `aggregateRecords`, `updateRecord` / `getRecord` overloads), `docs/cli.md` (`surql migrate|schema|db|orchestrate|settings` reference), `docs/migration.md` (upgrade notes v1.1.0 → v1.2.0 → v1.3.x). README refreshed with first-class helper examples (`typeRecord`, `timeNow`, `aggregateRecords`, `surql` CLI). mkdocs nav extended; `mkdocs build --strict` stays clean.
+- **Docs refresh** (#37): documented every release that landed since v1.0.0. New pages: `docs/v3-patterns.md` (buffered BEGIN/COMMIT, `IF NOT EXISTS` emitter, unrolled graph depth), `docs/query-ux.md` (`typeRecord` / `typeThing`, function factories, `FunctionValueExpression`, `extractMany` / `hasResult`, `aggregateRecords`, `updateRecord` / `getRecord` overloads), `docs/cli.md` (`surql migrate|schema|db|orchestrate|settings` reference), `docs/migration.md` (upgrade notes v1.1.0 → v1.2.0 → v1.3.x). README refreshed with first-class helper examples (`typeRecord`, `timeNow`, `aggregateRecords`, `surql` CLI). mkdocs nav extended; `mkdocs build --strict` stays clean.
 
 ### Housekeeping
 
@@ -22,7 +60,7 @@
 
 ## [1.3.0] - 2026-04-19
 
-### Added — Query-UX wave (#29)
+### Added — Query UX (#29)
 
 - **`typeRecord(table, id?)` / `typeThing(table, id?)`** (#6): first-class SurrealDB v3 record references. `typeThing` is the parity alias for surql-py/rs/go. Emits `type::record('table:id')` (v3-valid; v3 dropped `type::thing`).
 - **Function factories** (#7): `countIf`, `mathAbs`/`mathCeil`/`mathFloor`/`mathRound`, `stringLen`/`stringLower`/`stringUpper`/`stringConcat`. Short-form aliases (`abs_`, `ceil`, `floor`, `round_`, `upper`, `lower`, `concat`, `stringLength`) retained for pre-1.3.0 callers.
@@ -39,7 +77,7 @@
 
 ## [1.2.0] - 2026-04-19
 
-### Added — Parity wave (#19, #21, #24)
+### Added — Parity (#19, #21, #24)
 
 - **Structured schema parser** (#19): `parseDbInfo`, `parseTableInfo`, `parseFields`, `parseIndexes`, `parseEvents`, `parseAccess`, `parseEdgeInfo`, plus `SchemaParseError`. Full port of the surql-py/surql-rs/surql-go `DEFINE` parser (HNSW index, JWT URL/duration variants, lookbehind edge cases).
 - **Layered settings loader** (`loadSettings`, `getSettings`, `clearSettingsCache`, `getDbConfig`, `getMigrationPath`): reads env vars, `.env`, `surql.yaml`, and `surql.toml` with precedence matching the py/rs/go ports.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,29 @@
 # Changelog
 
-## [1.3.5] - 2026-05-15
+## [1.4.0] - 2026-05-17
+
+### Added
+
+- **Optional fields**: `FieldDefinition` gains an `optional` flag — e.g. `stringField('bio', { optional: true })`. The field type is emitted wrapped as `option<...>` (`option<string>`, `option<record<user>>`, `option<array<int>>`) so a `SCHEMAFULL` column accepts the absence of a value. Without it, every record that omits the column is rejected on SurrealDB v3 with a coercion error. The flag defaults off, so existing schemas are unaffected.
+- **WHERE filtering on graph traversal helpers**: `traverse`, `traverseWithDepth`, `getRelatedRecords`, `getOutgoingEdges`, `getIncomingEdges`, and `shortestPath` accept an optional trailing `conditions` argument — a raw SurrealQL predicate appended as a `WHERE` clause, matching the `conditions` argument `queryRecords` already takes. Callers that need row-level filtering (multi-tenant isolation, excluding archived rows) no longer have to drop down to a hand-written query. Omitting it leaves the emitted SurrealQL unchanged.
 
 ### Fixed
 
+- **`Transaction.commit()` discarded the per-statement results.** `Transaction.execute()` documents that the results "become available in the value returned by `commit()`", but `commit()` returned `void`. It now flushes the `BEGIN ...; COMMIT` batch through the SDK's `query(...).responses()` accessor: it returns the per-statement results of the queued statements in order, confirms the batch actually committed, and — on a rollback — names the statement that caused it instead of surfacing only a generic "failed transaction".
+- **Table and edge `PERMISSIONS` produced un-runnable DDL.** `generateTableSql` emitted table-level permissions as a *second* `DEFINE TABLE` statement; on SurrealDB v3 a repeat `DEFINE TABLE` for an existing table fails with `The table '<name>' already exists`, and on a server that did accept it the second statement redefined the table and silently dropped its `SCHEMAFULL`/`SCHEMALESS` mode. `generateEdgeSql` ignored `EdgeDefinition.permissions` entirely, so an edge built with `withEdgePermissions(...)` lost them. Both now fold permissions into the single `DEFINE TABLE` statement.
+- **`quoteValue()` flattened objects, RecordIds, and Dates with `JSON.stringify`.** A nested `SurrealFnValue`, `RecordId`, or `Date` was serialized as a JSON blob rather than SurrealQL — `{ created: <fn> }` came out as `{"created":{"__surqlFn":true,...}}`. `quoteValue()` now recurses through plain objects emitting SurrealQL object literals, renders `RecordId` instances as a record-id literal (`user:alice`), and renders `Date` instances as a `d'...'` datetime literal (a bare quoted ISO string is rejected by v3 datetime-typed fields).
+- **The migration differ emitted incomplete, mistyped DDL.** `ADD_FIELD`/`MODIFY_FIELD` diffs rendered a bare `TYPE <FieldType>`, dropping `record<target>`, array element types, and `option<...>`; `MODIFY_FIELD` only fired on a base-type change, so a changed record link or optionality went undetected. `ADD_TABLE` for a new table emitted only `DEFINE TABLE name mode;` — applying that migration created an empty table. Diffs now render field types through the shared generator, and a new table (or edge) emits its complete DDL.
 - **Docs**: corrected the "Buffered `BEGIN` / `COMMIT`" warning on the v3 Patterns page — the `Found COMMIT TRANSACTION, but ...` code span was immediately followed by the sentence period, rendering a stray trailing `....`.
 
 ### Changed
 
+- **CI**: the documentation workflow runs `mkdocs build --strict` on pull requests; closed open code-scanning alerts; added a label-driven Dependabot auto-merge workflow; moved CI and audit onto the `aur0` self-hosted runner; and added a scheduled `deno-update` workflow (#49–#54).
+- **CI**: hardened the workflow set so runs stop stalling — replaced `docs.yml`'s global `pages` concurrency group (which serialised every build and deploy across all refs behind one queue) with a per-ref group plus `cancel-in-progress`; promoted the `integration` and security `audit` workflows to PR gates on `ubuntu-latest` (from manual-only); added per-ref concurrency groups to the auto-merge, PR-title, and dependency-review workflows; and bumped pinned action versions. Completes #40 and absorbs dependabot PRs #56–#60.
 - **Docs**: replaced informal "wave" phrasing with neutral wording across `docs/query-ux.md`, `docs/migration.md`, and the changelog.
-- **CI**: the documentation workflow now runs `mkdocs build --strict` on pull requests, so broken links and nav errors are caught before merge instead of only in the post-merge deploy.
-- **CI**: closed open code-scanning alerts, added a label-driven Dependabot auto-merge workflow, moved CI/audit onto the `aur0` self-hosted runner, and added the scheduled `deno-update` workflow (#49–#54).
 
 ### Housekeeping
 
-- Version bumped to `1.3.5` in `deno.json`.
+- Version bumped to `1.4.0` in `deno.json`.
 
 ---
 

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "lock": true,
   "name": "@oneiriq/surql",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "license": "Apache-2.0",
   "exports": {
     ".": "./mod.ts",

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "lock": true,
   "name": "@oneiriq/surql",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "license": "Apache-2.0",
   "exports": {
     ".": "./mod.ts",

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -130,9 +130,14 @@ validateSchema(schema)
 generateMigrationFromDiffs(diffs, description)
 generateInitialMigration(upSql, description?)
 createBlankMigration(description)
-diffSchemas(before, after)
+generateMigrationFilename(description)
+diffTables(current, target)
+diffEdges(oldEdge, newEdge)
+migrateUp(db, migrations, targetVersion?)
+migrateDown(db, migrations, targetVersion?)
+createRollbackPlan(migrations, appliedVersions, targetVersion?)
+executeRollback(db, plan)
 validateMigrations(migrations)
-generateVersion()
 ```
 
 ## Orchestration

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@
 - **`quoteValue()` flattened objects, RecordIds, and Dates with `JSON.stringify`.** A nested `SurrealFnValue`, `RecordId`, or `Date` was serialized as a JSON blob rather than SurrealQL — `{ created: <fn> }` came out as `{"created":{"__surqlFn":true,...}}`. `quoteValue()` now recurses through plain objects emitting SurrealQL object literals, renders `RecordId` instances as a record-id literal (`user:alice`), and renders `Date` instances as a `d'...'` datetime literal (a bare quoted ISO string is rejected by v3 datetime-typed fields).
 - **The migration differ emitted incomplete, mistyped DDL.** `ADD_FIELD`/`MODIFY_FIELD` diffs rendered a bare `TYPE <FieldType>`, dropping `record<target>`, array element types, and `option<...>`; `MODIFY_FIELD` only fired on a base-type change, so a changed record link or optionality went undetected. `ADD_TABLE` for a new table emitted only `DEFINE TABLE name mode;` — applying that migration created an empty table. Diffs now render field types through the shared generator, and a new table (or edge) emits its complete DDL.
 - **Docs**: corrected the "Buffered `BEGIN` / `COMMIT`" warning on the v3 Patterns page — the `Found COMMIT TRANSACTION, but ...` code span was immediately followed by the sentence period, rendering a stray trailing `....`.
+- **Docs**: the migration documentation imported and called APIs that surql does not export (`diffSchemas`, `MigrationRunner`, `RollbackManager`, `generateVersion`, and others). Every such example is rewritten against the real exported API (#62).
 
 ### Changed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,10 +1,48 @@
 # Changelog
 
+## [1.3.5] - 2026-05-15
+
+### Fixed
+
+- **Docs**: corrected the "Buffered `BEGIN` / `COMMIT`" warning on the v3 Patterns page — the `Found COMMIT TRANSACTION, but ...` code span was immediately followed by the sentence period, rendering a stray trailing `....`.
+
+### Changed
+
+- **Docs**: replaced informal "wave" phrasing with neutral wording across `docs/query-ux.md`, `docs/migration.md`, and the changelog.
+- **CI**: the documentation workflow now runs `mkdocs build --strict` on pull requests, so broken links and nav errors are caught before merge instead of only in the post-merge deploy.
+- **CI**: closed open code-scanning alerts, added a label-driven Dependabot auto-merge workflow, moved CI/audit onto the `aur0` self-hosted runner, and added the scheduled `deno-update` workflow (#49–#54).
+
+### Housekeeping
+
+- Version bumped to `1.3.5` in `deno.json`.
+
+---
+
+## [1.3.4] - 2026-04-30
+
+### Fixed
+
+- **Publish**: corrected the npm package license metadata and skipped a redundant dnt typecheck (#48).
+
+---
+
+## [1.3.3] - 2026-04-30
+
+### Changed
+
+- **License**: relicensed to Apache-2.0 with a `NOTICE` file (#46).
+
+### Housekeeping
+
+- Trimmed auto-trigger workflows and bumped to `1.3.3` (#47).
+
+---
+
 ## [1.3.2] - 2026-04-19
 
 ### Changed
 
-- **Docs refresh** (#37): documented every wave that landed since v1.0.0. New pages: `docs/v3-patterns.md` (buffered BEGIN/COMMIT, `IF NOT EXISTS` emitter, unrolled graph depth), `docs/query-ux.md` (`typeRecord` / `typeThing`, function factories, `FunctionValueExpression`, `extractMany` / `hasResult`, `aggregateRecords`, `updateRecord` / `getRecord` overloads), `docs/cli.md` (`surql migrate|schema|db|orchestrate|settings` reference), `docs/migration.md` (upgrade notes v1.1.0 → v1.2.0 → v1.3.x). README refreshed with first-class helper examples (`typeRecord`, `timeNow`, `aggregateRecords`, `surql` CLI). mkdocs nav extended; `mkdocs build --strict` stays clean.
+- **Docs refresh** (#37): documented every release that landed since v1.0.0. New pages: `docs/v3-patterns.md` (buffered BEGIN/COMMIT, `IF NOT EXISTS` emitter, unrolled graph depth), `docs/query-ux.md` (`typeRecord` / `typeThing`, function factories, `FunctionValueExpression`, `extractMany` / `hasResult`, `aggregateRecords`, `updateRecord` / `getRecord` overloads), `docs/cli.md` (`surql migrate|schema|db|orchestrate|settings` reference), `docs/migration.md` (upgrade notes v1.1.0 → v1.2.0 → v1.3.x). README refreshed with first-class helper examples (`typeRecord`, `timeNow`, `aggregateRecords`, `surql` CLI). mkdocs nav extended; `mkdocs build --strict` stays clean.
 
 ### Housekeeping
 
@@ -22,7 +60,7 @@
 
 ## [1.3.0] - 2026-04-19
 
-### Added — Query-UX wave (#29)
+### Added — Query UX (#29)
 
 - **`typeRecord(table, id?)` / `typeThing(table, id?)`** (#6): first-class SurrealDB v3 record references. `typeThing` is the parity alias for surql-py/rs/go. Emits `type::record('table:id')` (v3-valid; v3 dropped `type::thing`).
 - **Function factories** (#7): `countIf`, `mathAbs`/`mathCeil`/`mathFloor`/`mathRound`, `stringLen`/`stringLower`/`stringUpper`/`stringConcat`. Short-form aliases (`abs_`, `ceil`, `floor`, `round_`, `upper`, `lower`, `concat`, `stringLength`) retained for pre-1.3.0 callers.
@@ -39,7 +77,7 @@
 
 ## [1.2.0] - 2026-04-19
 
-### Added — Parity wave (#19, #21, #24)
+### Added — Parity (#19, #21, #24)
 
 - **Structured schema parser** (#19): `parseDbInfo`, `parseTableInfo`, `parseFields`, `parseIndexes`, `parseEvents`, `parseAccess`, `parseEdgeInfo`, plus `SchemaParseError`. Full port of the surql-py/surql-rs/surql-go `DEFINE` parser (HNSW index, JWT URL/duration variants, lookbehind edge cases).
 - **Layered settings loader** (`loadSettings`, `getSettings`, `clearSettingsCache`, `getDbConfig`, `getMigrationPath`): reads env vars, `.env`, `surql.yaml`, and `surql.toml` with precedence matching the py/rs/go ports.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,20 +1,29 @@
 # Changelog
 
-## [1.3.5] - 2026-05-15
+## [1.4.0] - 2026-05-17
+
+### Added
+
+- **Optional fields**: `FieldDefinition` gains an `optional` flag — e.g. `stringField('bio', { optional: true })`. The field type is emitted wrapped as `option<...>` (`option<string>`, `option<record<user>>`, `option<array<int>>`) so a `SCHEMAFULL` column accepts the absence of a value. Without it, every record that omits the column is rejected on SurrealDB v3 with a coercion error. The flag defaults off, so existing schemas are unaffected.
+- **WHERE filtering on graph traversal helpers**: `traverse`, `traverseWithDepth`, `getRelatedRecords`, `getOutgoingEdges`, `getIncomingEdges`, and `shortestPath` accept an optional trailing `conditions` argument — a raw SurrealQL predicate appended as a `WHERE` clause, matching the `conditions` argument `queryRecords` already takes. Callers that need row-level filtering (multi-tenant isolation, excluding archived rows) no longer have to drop down to a hand-written query. Omitting it leaves the emitted SurrealQL unchanged.
 
 ### Fixed
 
+- **`Transaction.commit()` discarded the per-statement results.** `Transaction.execute()` documents that the results "become available in the value returned by `commit()`", but `commit()` returned `void`. It now flushes the `BEGIN ...; COMMIT` batch through the SDK's `query(...).responses()` accessor: it returns the per-statement results of the queued statements in order, confirms the batch actually committed, and — on a rollback — names the statement that caused it instead of surfacing only a generic "failed transaction".
+- **Table and edge `PERMISSIONS` produced un-runnable DDL.** `generateTableSql` emitted table-level permissions as a *second* `DEFINE TABLE` statement; on SurrealDB v3 a repeat `DEFINE TABLE` for an existing table fails with `The table '<name>' already exists`, and on a server that did accept it the second statement redefined the table and silently dropped its `SCHEMAFULL`/`SCHEMALESS` mode. `generateEdgeSql` ignored `EdgeDefinition.permissions` entirely, so an edge built with `withEdgePermissions(...)` lost them. Both now fold permissions into the single `DEFINE TABLE` statement.
+- **`quoteValue()` flattened objects, RecordIds, and Dates with `JSON.stringify`.** A nested `SurrealFnValue`, `RecordId`, or `Date` was serialized as a JSON blob rather than SurrealQL — `{ created: <fn> }` came out as `{"created":{"__surqlFn":true,...}}`. `quoteValue()` now recurses through plain objects emitting SurrealQL object literals, renders `RecordId` instances as a record-id literal (`user:alice`), and renders `Date` instances as a `d'...'` datetime literal (a bare quoted ISO string is rejected by v3 datetime-typed fields).
+- **The migration differ emitted incomplete, mistyped DDL.** `ADD_FIELD`/`MODIFY_FIELD` diffs rendered a bare `TYPE <FieldType>`, dropping `record<target>`, array element types, and `option<...>`; `MODIFY_FIELD` only fired on a base-type change, so a changed record link or optionality went undetected. `ADD_TABLE` for a new table emitted only `DEFINE TABLE name mode;` — applying that migration created an empty table. Diffs now render field types through the shared generator, and a new table (or edge) emits its complete DDL.
 - **Docs**: corrected the "Buffered `BEGIN` / `COMMIT`" warning on the v3 Patterns page — the `Found COMMIT TRANSACTION, but ...` code span was immediately followed by the sentence period, rendering a stray trailing `....`.
 
 ### Changed
 
+- **CI**: the documentation workflow runs `mkdocs build --strict` on pull requests; closed open code-scanning alerts; added a label-driven Dependabot auto-merge workflow; moved CI and audit onto the `aur0` self-hosted runner; and added a scheduled `deno-update` workflow (#49–#54).
+- **CI**: hardened the workflow set so runs stop stalling — replaced `docs.yml`'s global `pages` concurrency group (which serialised every build and deploy across all refs behind one queue) with a per-ref group plus `cancel-in-progress`; promoted the `integration` and security `audit` workflows to PR gates on `ubuntu-latest` (from manual-only); added per-ref concurrency groups to the auto-merge, PR-title, and dependency-review workflows; and bumped pinned action versions. Completes #40 and absorbs dependabot PRs #56–#60.
 - **Docs**: replaced informal "wave" phrasing with neutral wording across `docs/query-ux.md`, `docs/migration.md`, and the changelog.
-- **CI**: the documentation workflow now runs `mkdocs build --strict` on pull requests, so broken links and nav errors are caught before merge instead of only in the post-merge deploy.
-- **CI**: closed open code-scanning alerts, added a label-driven Dependabot auto-merge workflow, moved CI/audit onto the `aur0` self-hosted runner, and added the scheduled `deno-update` workflow (#49–#54).
 
 ### Housekeeping
 
-- Version bumped to `1.3.5` in `deno.json`.
+- Version bumped to `1.4.0` in `deno.json`.
 
 ---
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -79,12 +79,16 @@ const users = await client.query<UserRaw, UserDto>('users')
 
 ```typescript
 import {
-  tableSchema, withFields, withIndexes,
-  stringField, intField, index,
-  TableMode,
-  diffSchemas,
+  diffTables,
   generateMigrationFromDiffs,
-  MigrationRunner,
+  intField,
+  migrateUp,
+  stringField,
+  tableSchema,
+  TableMode,
+  uniqueIndex,
+  withFields,
+  withIndexes,
 } from 'jsr:@oneiriq/surql'
 
 // Define schema
@@ -95,22 +99,20 @@ const userSchema = withIndexes(
     stringField('email'),
     intField('age'),
   ),
-  index('email_idx', 'email', { unique: true }),
+  uniqueIndex('email_idx', 'email'),
 )
 
-// Generate migration from diff
-const diffs = diffSchemas({ tables: [] }, { tables: [userSchema] })
+// Generate a migration from a diff against an empty schema
+const diffs = diffTables([], [userSchema])
 const migration = generateMigrationFromDiffs(diffs, 'create_users')
 
-// Apply migration
-const runner = new MigrationRunner(client, [{
+// Apply migration — `db` is a connected Surreal connection
+await migrateUp(db, [{
   version: '20240101000001',
   description: 'create_users',
   up: async () => migration.upSql,
   down: async () => migration.downSql,
 }])
-
-await runner.up()
 console.log('Migration applied')
 ```
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -51,7 +51,7 @@ All additive; the old APIs keep working.
 - **Schema drift hooks** (`checkSchemaDrift`, `generatePrecommitConfig`, `watchSchema`) plug into git pre-commit and live dev loops.
 - **`surql` CLI** (`deno task cli …` or `jsr:@oneiriq/surql/cli`). See the [CLI reference](cli.md).
 
-## v1.2.0 → v1.3.0 (Query-UX wave)
+## v1.2.0 → v1.3.0 (Query UX)
 
 ### Adopt `typeRecord` / `typeThing` for record references
 
@@ -127,7 +127,7 @@ CI-only fix: `src/test/integration*.test.ts` is now excluded from the publish-ti
 
 ## v1.3.1 → v1.3.2
 
-Documentation refresh only. No code changes. The rendered site now covers every wave that landed since v1.0.0 (v3 patterns, query UX, CLI, upgrade notes). `deno.json` is bumped to `1.3.2` so the refreshed docs publish alongside the version.
+Documentation refresh only. No code changes. The rendered site now covers every release that landed since v1.0.0 (v3 patterns, query UX, CLI, upgrade notes). `deno.json` is bumped to `1.3.2` so the refreshed docs publish alongside the version.
 
 ## Developer experience — enable the pre-push hook
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -10,10 +10,10 @@ A migration is an object implementing the `Migration` interface:
 import type { Migration } from 'jsr:@oneiriq/surql'
 
 const migration: Migration = {
-  version: '20240101000001',   // Sortable timestamp string
+  version: '20240101000001', // Sortable timestamp string
   description: 'create_users',
-  up: async () => 'DEFINE TABLE users SCHEMAFULL; DEFINE FIELD name ON TABLE users TYPE string;',
-  down: async () => 'REMOVE TABLE users;',
+  up: () => Promise.resolve('DEFINE TABLE users SCHEMAFULL; DEFINE FIELD name ON TABLE users TYPE string;'),
+  down: () => Promise.resolve('REMOVE TABLE users;'),
 }
 ```
 
@@ -21,19 +21,16 @@ const migration: Migration = {
 
 ### From Schema Diffs
 
+`diffTables` compares two arrays of `TableDefinition` — the current schema and the target schema — and returns the operations needed to go from one to the other. `generateMigrationFromDiffs` turns those into migration SQL.
+
 ```typescript
-import {
-  diffSchemas,
-  generateMigrationFromDiffs,
-} from 'jsr:@oneiriq/surql'
+import { diffTables, generateMigrationFromDiffs } from 'jsr:@oneiriq/surql'
 
-const before = { tables: [] }
-const after = { tables: [userSchema, postSchema] }
-
-const diffs = diffSchemas(before, after)
+// Diff an empty schema against the desired tables.
+const diffs = diffTables([], [userSchema, postSchema])
 const migration = generateMigrationFromDiffs(diffs, 'create_users_posts')
 
-console.log(migration.filename)  // e.g. 20240101000001_create_users_posts.surql
+console.log(migration.filename) // e.g. 20240101000001_create_users_posts.surql
 console.log(migration.upSql)
 console.log(migration.downSql)
 ```
@@ -60,72 +57,71 @@ const initial = generateInitialMigration(
 
 ## Running Migrations
 
-### MigrationRunner
+`migrateUp` and `migrateDown` take a connected `Surreal` connection and the list of migrations. `migrateUp` applies every migration not yet recorded in the migration-history table and returns the statuses of the migrations it applied.
 
 ```typescript
-import { MigrationRunner } from 'jsr:@oneiriq/surql'
+import { migrateDown, migrateUp } from 'jsr:@oneiriq/surql'
 
-const runner = new MigrationRunner(client, [migration1, migration2])
+// Apply all pending migrations.
+const applied = await migrateUp(db, [migration1, migration2])
+console.log(applied) // MigrationStatus[]
 
-// Apply all pending migrations
-await runner.up()
+// Revert the most recent migrations down to a target version.
+await migrateDown(db, [migration1, migration2], '20240101000001')
+```
 
-// Roll back the last applied migration
-await runner.down()
+### Migration Status
 
-// Check status
-const status = await runner.status()
-console.log(status)  // { applied: string[], pending: string[] }
+```typescript
+import { getAppliedVersions, getMigrationStatus, getPendingMigrations } from 'jsr:@oneiriq/surql'
+
+const appliedVersions = await getAppliedVersions(db)
+const status = getMigrationStatus(migrations, appliedVersions)
+// MigrationStatus[] — each entry is APPLIED or PENDING
+
+const pending = await getPendingMigrations(db, migrations)
 ```
 
 ### Applying Specific Versions
 
-```typescript
-// Apply up to a specific version
-await runner.upTo('20240101000002')
+Both `migrateUp` and `migrateDown` accept an optional target version. `migrateUp` applies pending migrations up to and including the target; `migrateDown` reverts every applied migration above the target.
 
-// Roll back to a specific version
-await runner.downTo('20240101000001')
+```typescript
+// Apply pending migrations up to a specific version.
+await migrateUp(db, migrations, '20240101000002')
+
+// Revert down to a specific version.
+await migrateDown(db, migrations, '20240101000001')
 ```
 
 ## Migration Discovery
 
-Load migrations from `.surql` files:
+Discover and load migrations from a directory of `.surql` (or `.ts`) files named `YYYYMMDDHHMMSS_description.surql`:
 
 ```typescript
-import { loadMigrationsFromDir } from 'jsr:@oneiriq/surql'
+import { discoverMigrations, loadMigration } from 'jsr:@oneiriq/surql'
 
-const migrations = await loadMigrationsFromDir('./migrations')
-const runner = new MigrationRunner(client, migrations)
+const metadata = await discoverMigrations('./migrations')
+const migrations = await Promise.all(
+  metadata.map((m) => loadMigration(m.filepath)),
+)
+await migrateUp(db, migrations)
 ```
 
 ## Versioning
 
-Migration versions use a sortable format: `YYYYMMDDHHMMSS`.
+Migration versions are sortable 14-digit timestamps (`YYYYMMDDHHMMSS`). `generateMigrationFilename` produces a `<version>_<slug>.surql` filename for a new migration:
 
 ```typescript
-import { generateVersion } from 'jsr:@oneiriq/surql'
+import { generateMigrationFilename } from 'jsr:@oneiriq/surql'
 
-const version = generateVersion()  // e.g. '20240101120000'
-```
-
-## Rollback
-
-```typescript
-import { RollbackManager } from 'jsr:@oneiriq/surql'
-
-const manager = new RollbackManager(client, migrations)
-
-// Rollback last N migrations
-await manager.rollback(3)
-
-// Rollback to checkpoint
-await manager.rollbackTo('20240101000001')
+const filename = generateMigrationFilename('add index to users')
+// e.g. 20240101120000_add_index_to_users.surql
 ```
 
 ## Validation
 
-Validate a set of migrations before applying them:
+Validate a set of migrations before applying them — `validateMigrations` reports duplicate versions and other consistency problems:
 
 ```typescript
 import { validateMigrations } from 'jsr:@oneiriq/surql'
@@ -139,4 +135,4 @@ if (issues.length > 0) {
 ## Next Steps
 
 - [Orchestration](orchestration.md) - Deploy migrations across multiple environments
-- [Versioning & Rollback](versioning_rollback.md) - Advanced rollback strategies
+- [Versioning & Rollback](versioning_rollback.md) - Rollback strategies

--- a/docs/query-ux.md
+++ b/docs/query-ux.md
@@ -1,6 +1,6 @@
 # Query UX
 
-The v1.3.x query-UX wave fills in first-class helpers for the patterns callers were previously reaching into `raw()` / `surqlFn()` for. This page shows the before/after for each helper.
+The v1.3.x query-UX release fills in first-class helpers for the patterns callers were previously reaching into `raw()` / `surqlFn()` for. This page shows the before/after for each helper.
 
 ## `typeRecord` / `typeThing` references
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -77,9 +77,9 @@ const postSchema = withFields(
 ## 4. Generate a Migration
 
 ```typescript
-import { generateMigrationFromDiffs, diffSchemas } from 'jsr:@oneiriq/surql'
+import { diffTables, generateMigrationFromDiffs } from 'jsr:@oneiriq/surql'
 
-const diffs = diffSchemas({ tables: [] }, { tables: [userSchema, postSchema] })
+const diffs = diffTables([], [userSchema, postSchema])
 const migration = generateMigrationFromDiffs(diffs, 'create_users_posts')
 
 console.log(migration.upSql)
@@ -89,9 +89,10 @@ console.log(migration.downSql)
 ## 5. Apply the Migration
 
 ```typescript
-import { MigrationRunner } from 'jsr:@oneiriq/surql'
+import { migrateUp } from 'jsr:@oneiriq/surql'
 
-const runner = new MigrationRunner(client, [
+// `db` is a connected Surreal connection.
+await migrateUp(db, [
   {
     version: '20240101000001',
     description: 'create_users_posts',
@@ -99,8 +100,6 @@ const runner = new MigrationRunner(client, [
     down: async () => migration.downSql,
   },
 ])
-
-await runner.up()
 ```
 
 ## 6. CRUD Operations

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -148,12 +148,11 @@ const schema: SchemaDefinition = {
 Generate diffs between two schema states:
 
 ```typescript
-import { diffSchemas } from 'jsr:@oneiriq/surql'
+import { diffTables } from 'jsr:@oneiriq/surql'
 
-const before: SchemaDefinition = { tables: [] }
-const after: SchemaDefinition = { tables: [users, posts] }
-
-const diffs = diffSchemas(before, after)
+// diffTables compares two arrays of TableDefinition — the current
+// schema and the target schema.
+const diffs = diffTables([], [users, posts])
 // Returns: SchemaDiff[]
 ```
 

--- a/docs/v3-patterns.md
+++ b/docs/v3-patterns.md
@@ -19,7 +19,7 @@ await tx.commit() // issues BEGIN TRANSACTION; ...; COMMIT TRANSACTION; in one R
 ```
 
 !!! warning "Do not stream statements"
-    Splitting `BEGIN TRANSACTION` and `COMMIT TRANSACTION` across separate `db.query()` calls worked on v1/v2 but fails on v3 with `Found COMMIT TRANSACTION, but ...`.
+    Splitting `BEGIN TRANSACTION` and `COMMIT TRANSACTION` across separate `db.query()` calls worked on v1/v2 but is rejected on v3 with a `Found COMMIT TRANSACTION, but ...` parse error.
 
 `Transaction.cancel()` discards the buffer client-side without ever contacting the server. `Transaction` also implements `Symbol.asyncDispose` so `await using tx = transaction(db)` auto-cancels if the block exits without committing.
 

--- a/docs/versioning_rollback.md
+++ b/docs/versioning_rollback.md
@@ -4,72 +4,78 @@ surql provides versioning support and rollback capabilities for migration manage
 
 ## Migration Versioning
 
-Migrations use sortable timestamp-based version strings (`YYYYMMDDHHMMSS`).
+Migrations use sortable 14-digit timestamp version strings (`YYYYMMDDHHMMSS`). `generateMigrationFilename` produces the `<version>_<slug>.surql` filename for a new migration; the version is its timestamp prefix.
 
 ```typescript
-import { generateVersion } from 'jsr:@oneiriq/surql'
+import { generateMigrationFilename } from 'jsr:@oneiriq/surql'
 
-const version = generateVersion()
-// e.g. '20240101120000'
+const filename = generateMigrationFilename('add user roles')
+// e.g. 20240101120000_add_user_roles.surql
 ```
 
-## MigrationRunner
+## Applying and Reverting Migrations
+
+`migrateUp` applies every pending migration; `migrateDown` reverts applied migrations down to a target version (or all of them when no target is given).
 
 ```typescript
-import { MigrationRunner } from 'jsr:@oneiriq/surql'
+import { getAppliedVersions, getMigrationStatus, migrateDown, migrateUp } from 'jsr:@oneiriq/surql'
 
-const runner = new MigrationRunner(client, migrations)
+// Apply all pending migrations.
+await migrateUp(db, migrations)
 
-// View migration status
-const status = await runner.status()
-// { applied: string[], pending: string[] }
+// Inspect what is applied vs pending.
+const status = getMigrationStatus(migrations, await getAppliedVersions(db))
 
-// Apply all pending migrations
-await runner.up()
-
-// Roll back the most recently applied migration
-await runner.down()
+// Revert the most recent migration(s) down to a target version.
+await migrateDown(db, migrations, '20240101000001')
 ```
 
-## Targeted Rollback
+## Rollback Planning
+
+For a controlled rollback, build a plan first. `createRollbackPlan` selects the applied migrations to revert and reports a safety assessment; `executeRollback` runs the plan and returns which migrations were reverted.
 
 ```typescript
-// Roll back to a specific version (inclusive rollback)
-await runner.downTo('20240101000001')
+import {
+  createRollbackPlan,
+  executeRollback,
+  getAppliedVersions,
+} from 'jsr:@oneiriq/surql'
+
+const appliedVersions = await getAppliedVersions(db)
+
+// Plan a rollback down to a target version (omit the version to revert all).
+const plan = createRollbackPlan(migrations, appliedVersions, '20240101000001')
+
+console.log(plan.safety) // SAFE | WARNING | UNSAFE
+console.log(plan.issues) // RollbackIssue[] — per-migration warnings
+
+if (plan.safety !== 'UNSAFE') {
+  const result = await executeRollback(db, plan)
+  console.log(result.success, result.migrationsRolledBack)
+}
 ```
 
-## RollbackManager
+`planRollbackToVersion(migrations, appliedVersions, targetVersion)` is a convenience wrapper that always requires an explicit target version.
 
-For more granular control:
+## Rollback Safety
 
-```typescript
-import { RollbackManager } from 'jsr:@oneiriq/surql'
-
-const manager = new RollbackManager(client, migrations)
-
-// Roll back the last N applied migrations
-await manager.rollback(3)
-
-// Roll back to a named checkpoint
-await manager.rollbackTo('20240101000001')
-```
-
-## Creating Rollback Checkpoints
+`analyzeRollbackSafety` classifies a set of schema diffs as `SAFE`, `WARNING`, or `UNSAFE` — a diff that drops a table or field is `UNSAFE`. Use it to gate a rollback in CI:
 
 ```typescript
-import { createCheckpoint } from 'jsr:@oneiriq/surql'
+import { analyzeRollbackSafety } from 'jsr:@oneiriq/surql'
 
-// Save current applied migration state as a checkpoint
-await createCheckpoint(client, 'before_refactor')
-
-// Restore from checkpoint
-await manager.rollbackToCheckpoint('before_refactor')
+const safety = analyzeRollbackSafety(diffs)
+if (safety === 'UNSAFE') {
+  console.error('Rollback would drop data — aborting')
+}
 ```
 
 ## Version History
 
 ```typescript
-const history = await runner.getHistory()
+import { getAppliedMigrations } from 'jsr:@oneiriq/surql'
+
+const history = await getAppliedMigrations(db)
 for (const entry of history) {
   console.log(`${entry.version} applied at ${entry.appliedAt}`)
 }
@@ -83,17 +89,16 @@ import { validateMigrations } from 'jsr:@oneiriq/surql'
 const issues = validateMigrations(migrations)
 if (issues.length > 0) {
   console.error('Validation failed:', issues)
-  process.exit(1)
 }
 
-await runner.up()
+await migrateUp(db, migrations)
 ```
 
 ## Best Practices
 
 - Always write a `down` function for every migration
 - Test rollback paths before applying to production
-- Use `RollbackManager.rollback(1)` to verify `down()` works after each migration
+- Inspect `createRollbackPlan(...).safety` before reverting in production
 - Run `validateMigrations()` in CI before deploying
 
 ## Next Steps

--- a/src/connection/transaction.ts
+++ b/src/connection/transaction.ts
@@ -14,6 +14,65 @@ export enum TransactionState {
 }
 
 /**
+ * One per-statement entry from the SurrealDB JS SDK's `query(...).responses()`
+ * accessor. Awaiting a query collects the results and rejects on the first
+ * failed statement; `.responses()` instead resolves with the full
+ * per-statement envelope, so a `BEGIN ...; COMMIT` batch can be inspected as a
+ * whole — distinguishing a clean commit from a server-side rollback and naming
+ * the statement that caused it.
+ */
+interface RawQueryResponse {
+  readonly success: boolean
+  readonly result?: unknown
+  readonly error?: {
+    readonly kind?: string
+    readonly code?: number
+    readonly details?: { readonly kind?: string } | null
+  }
+}
+
+/**
+ * Inspect the per-statement envelope returned for a committed
+ * `BEGIN ...; COMMIT` batch.
+ *
+ * `responses[0]` is the BEGIN bookend and the trailing entry is COMMIT; the
+ * `userCount` entries in between map 1:1, in order, to the statements queued
+ * via {@link Transaction.execute}. A SurrealDB v3 transaction is atomic — a
+ * single failed statement rolls the whole batch back — so any `success: false`
+ * entry means nothing was committed.
+ *
+ * The rolled-back statements are flagged with a `NotExecuted` cascade error;
+ * the originating failure is the first entry whose error is not that cascade.
+ */
+function inspectCommitResponses(
+  responses: readonly RawQueryResponse[],
+  userCount: number,
+): { committed: true; results: unknown[] } | { committed: false; reason: string } {
+  const firstFailure = responses.findIndex((r) => !r.success)
+  if (firstFailure === -1) {
+    // [ BEGIN, ...userCount statements, COMMIT ] — return just the user results.
+    return { committed: true, results: responses.slice(1, 1 + userCount).map((r) => r.result) }
+  }
+
+  let causeIndex = responses.findIndex((r) => !r.success && r.error?.details?.kind !== 'NotExecuted')
+  if (causeIndex === -1) causeIndex = firstFailure
+  const kind = responses[causeIndex].error?.kind ?? 'unknown error'
+
+  let where: string
+  if (causeIndex === 0) {
+    where = 'the BEGIN statement'
+  } else if (causeIndex <= userCount) {
+    where = `statement ${causeIndex} of ${userCount}`
+  } else {
+    where = 'the COMMIT statement'
+  }
+  return {
+    committed: false,
+    reason: `${where} failed (${kind}), so the whole batch was rolled back`,
+  }
+}
+
+/**
  * Transaction that buffers statements client-side and flushes them as a
  * single `BEGIN TRANSACTION; ...; COMMIT TRANSACTION;` request on commit.
  *
@@ -62,9 +121,9 @@ export class Transaction {
   /**
    * Queue a statement for execution inside the transaction.
    *
-   * The statement is not executed until {@link commit} is called.
-   * Returns an empty array; the real per-statement results become
-   * available in the value returned by `commit()`.
+   * The statement is not executed until {@link commit} is called. This call
+   * returns an empty array — the real per-statement results become available,
+   * in queue order, in the array returned by {@link commit}.
    */
   // deno-lint-ignore require-await
   async execute<T>(query: string, _params?: Record<string, unknown>): Promise<T[]> {
@@ -77,29 +136,43 @@ export class Transaction {
   }
 
   /**
-   * Flush buffered statements as a single atomic query.
+   * Flush buffered statements as a single atomic `BEGIN ...; COMMIT` request
+   * and return the per-statement results, in queue order, of the statements
+   * passed to {@link execute}.
    *
-   * Emits `BEGIN TRANSACTION; <stmt>; ...; COMMIT TRANSACTION;` in one
-   * RPC call. On failure the transaction is moved to `FAILED` and the
-   * error is re-thrown wrapped as a SurQL error.
+   * The batch is sent through the SDK's `responses()` accessor rather than a
+   * plain `await`. A SurrealDB v3 transaction is atomic, so a single failed
+   * statement rolls the entire batch back; `responses()` exposes the
+   * per-statement envelope, letting `commit()` confirm the batch actually
+   * committed and name the statement that caused a rollback. A bare
+   * `await db.query(...)` only ever surfaces a generic "failed transaction"
+   * message with no indication of which statement was at fault.
+   *
+   * On a rollback (or transport failure) the transaction moves to `FAILED`
+   * and a {@link TransactionError} is thrown.
    */
-  async commit(): Promise<void> {
+  async commit(): Promise<unknown[]> {
     if (this._state !== TransactionState.ACTIVE) {
       throw new TransactionError(`Cannot commit transaction in state: ${this._state}`)
     }
-    const parts: string[] = ['BEGIN TRANSACTION']
-    for (const stmt of this.statements) {
-      parts.push(stmt)
-    }
-    parts.push('COMMIT TRANSACTION')
+    const parts: string[] = ['BEGIN TRANSACTION', ...this.statements, 'COMMIT TRANSACTION']
     const surql = parts.join(';\n') + ';'
+
+    let responses: RawQueryResponse[]
     try {
-      await this.db.query(surql)
-      this._state = TransactionState.COMMITTED
+      responses = (await this.db.query(surql).responses()) as unknown as RawQueryResponse[]
     } catch (e) {
       this._state = TransactionState.FAILED
       throw intoSurQlError('Failed to commit transaction:', e)
     }
+
+    const outcome = inspectCommitResponses(responses, this.statements.length)
+    if (!outcome.committed) {
+      this._state = TransactionState.FAILED
+      throw new TransactionError(`Failed to commit transaction: ${outcome.reason}`)
+    }
+    this._state = TransactionState.COMMITTED
+    return outcome.results
   }
 
   /**

--- a/src/migration/diff.ts
+++ b/src/migration/diff.ts
@@ -1,6 +1,7 @@
 import type { EdgeDefinition } from '../schema/edge.ts'
 import type { FieldDefinition } from '../schema/fields.ts'
 import { type IndexDefinition, IndexType, type TableDefinition } from '../schema/table.ts'
+import { fieldTypeToSql, generateEdgeSql, generateTableSql } from '../schema/sql.ts'
 import { DiffOperation, type SchemaDiff } from './models.ts'
 
 /**
@@ -14,14 +15,17 @@ export function diffTables(
   const currentMap = new Map(current.map((t) => [t.name, t]))
   const targetMap = new Map(target.map((t) => [t.name, t]))
 
-  // Added tables
+  // Added tables — emit the complete table DDL (mode, permissions, fields,
+  // indexes, events). A bare `DEFINE TABLE name mode;` would apply a migration
+  // that creates an empty table, silently dropping every column, index, and
+  // event the target schema declared.
   for (const [name, table] of targetMap) {
     if (!currentMap.has(name)) {
       diffs.push({
         operation: DiffOperation.ADD_TABLE,
         table: name,
         details: `Add table '${name}' (${table.mode})`,
-        sql: `DEFINE TABLE ${name} ${table.mode};`,
+        sql: generateTableSql(table),
       })
     }
   }
@@ -70,7 +74,7 @@ export function diffFields(
         table: tableName,
         field: name,
         details: `Add field '${name}' (${field.type})`,
-        sql: `DEFINE FIELD ${name} ON TABLE ${tableName} TYPE ${field.type};`,
+        sql: `DEFINE FIELD ${name} ON TABLE ${tableName} TYPE ${fieldTypeToSql(field)};`,
       })
     }
   }
@@ -91,13 +95,18 @@ export function diffFields(
     const currentField = currentMap.get(name)
     if (!currentField) continue
 
-    if (currentField.type !== targetField.type) {
+    // Compare the fully-rendered type so a changed record link
+    // (`record<a>` -> `record<b>`), array element type, or optionality is
+    // detected — not only a change of the base `FieldType`.
+    const currentType = fieldTypeToSql(currentField)
+    const targetType = fieldTypeToSql(targetField)
+    if (currentType !== targetType) {
       diffs.push({
         operation: DiffOperation.MODIFY_FIELD,
         table: tableName,
         field: name,
-        details: `Modify field '${name}': ${currentField.type} -> ${targetField.type}`,
-        sql: `DEFINE FIELD ${name} ON TABLE ${tableName} TYPE ${targetField.type};`,
+        details: `Modify field '${name}': ${currentType} -> ${targetType}`,
+        sql: `DEFINE FIELD ${name} ON TABLE ${tableName} TYPE ${targetType};`,
       })
     }
   }
@@ -231,13 +240,14 @@ export function diffEdges(
 ): SchemaDiff[] {
   const diffs: SchemaDiff[] = []
 
-  // Edge added
+  // Edge added — emit the complete relation DDL (FROM/TO constraints,
+  // permissions, fields, indexes, events) rather than a bare DEFINE TABLE.
   if (oldEdge === null && newEdge !== null) {
     diffs.push({
       operation: DiffOperation.ADD_TABLE,
       table: newEdge.name,
       details: `Add edge '${newEdge.name}'`,
-      sql: `DEFINE TABLE ${newEdge.name} TYPE RELATION;`,
+      sql: generateEdgeSql(newEdge),
     })
     return diffs
   }

--- a/src/query/graph.ts
+++ b/src/query/graph.ts
@@ -3,15 +3,32 @@ import { intoSurQlError } from '../utils/surrealError.ts'
 import { quoteValue, validateIdentifier } from './helpers.ts'
 
 /**
- * Traverse a graph path from a starting record
+ * Render an optional `WHERE` clause for a graph query.
+ *
+ * Returns the clause with a leading space, or an empty string when no
+ * condition is supplied, so callers can append it unconditionally. The
+ * condition is a raw SurrealQL predicate — the same shape `queryRecords`
+ * accepts.
+ */
+function whereClause(conditions?: string): string {
+  return conditions ? ` WHERE ${conditions}` : ''
+}
+
+/**
+ * Traverse a graph path from a starting record.
+ *
+ * Pass `conditions` (a raw SurrealQL predicate) to filter the traversed
+ * records — e.g. multi-tenant isolation or excluding archived rows. Without
+ * it the traversal is unfiltered, as before.
  */
 export async function traverse<T = Record<string, unknown>>(
   db: Surreal,
   start: string,
   path: string,
+  conditions?: string,
 ): Promise<T[]> {
   try {
-    const sql = `SELECT * FROM ${start}.${path}`
+    const sql = `SELECT * FROM ${start}.${path}${whereClause(conditions)}`
     const results = await db.query<T[]>(sql) as unknown as T[][]
     return results[0] || ([] as T[])
   } catch (e) {
@@ -20,18 +37,23 @@ export async function traverse<T = Record<string, unknown>>(
 }
 
 /**
- * Traverse with explicit depth control
+ * Traverse with explicit depth control.
+ *
+ * Pass `conditions` (a raw SurrealQL predicate) to filter the traversed
+ * records.
  */
 export async function traverseWithDepth<T = Record<string, unknown>>(
   db: Surreal,
   start: string,
   edgeTable: string,
   direction: '->' | '<-' | '<->',
-  depth: number = 1,
+  depth?: number,
+  conditions?: string,
 ): Promise<T[]> {
   try {
-    const path = Array.from({ length: depth }, () => `${direction}${edgeTable}`).join('')
-    const sql = `SELECT * FROM ${start}${path}.*`
+    const hops = depth ?? 1
+    const path = Array.from({ length: hops }, () => `${direction}${edgeTable}`).join('')
+    const sql = `SELECT * FROM ${start}${path}.*${whereClause(conditions)}`
     const results = await db.query<T[]>(sql) as unknown as T[][]
     return results[0] || ([] as T[])
   } catch (e) {
@@ -80,16 +102,21 @@ export async function removeRelation(
 }
 
 /**
- * Get records related via a specific edge
+ * Get records related via a specific edge.
+ *
+ * Pass `conditions` (a raw SurrealQL predicate) to filter the related
+ * records.
  */
 export async function getRelatedRecords<T = Record<string, unknown>>(
   db: Surreal,
   record: string,
   edge: string,
-  direction: '->' | '<-' = '->',
+  direction?: '->' | '<-',
+  conditions?: string,
 ): Promise<T[]> {
   try {
-    const sql = `SELECT * FROM ${record}${direction}${edge}.*`
+    const dir = direction ?? '->'
+    const sql = `SELECT * FROM ${record}${dir}${edge}.*${whereClause(conditions)}`
     const results = await db.query<T[]>(sql) as unknown as T[][]
     return results[0] || ([] as T[])
   } catch (e) {
@@ -98,15 +125,18 @@ export async function getRelatedRecords<T = Record<string, unknown>>(
 }
 
 /**
- * Get outgoing edges from a record
+ * Get outgoing edges from a record.
+ *
+ * Pass `conditions` (a raw SurrealQL predicate) to filter the matched edges.
  */
 export async function getOutgoingEdges<T = Record<string, unknown>>(
   db: Surreal,
   record: string,
   edge: string,
+  conditions?: string,
 ): Promise<T[]> {
   try {
-    const sql = `SELECT * FROM ${record}->${edge}`
+    const sql = `SELECT * FROM ${record}->${edge}${whereClause(conditions)}`
     const results = await db.query<T[]>(sql) as unknown as T[][]
     return results[0] || ([] as T[])
   } catch (e) {
@@ -115,15 +145,18 @@ export async function getOutgoingEdges<T = Record<string, unknown>>(
 }
 
 /**
- * Get incoming edges to a record
+ * Get incoming edges to a record.
+ *
+ * Pass `conditions` (a raw SurrealQL predicate) to filter the matched edges.
  */
 export async function getIncomingEdges<T = Record<string, unknown>>(
   db: Surreal,
   record: string,
   edge: string,
+  conditions?: string,
 ): Promise<T[]> {
   try {
-    const sql = `SELECT * FROM ${record}<-${edge}`
+    const sql = `SELECT * FROM ${record}<-${edge}${whereClause(conditions)}`
     const results = await db.query<T[]>(sql) as unknown as T[][]
     return results[0] || ([] as T[])
   } catch (e) {
@@ -150,20 +183,24 @@ export async function countRelated(
 }
 
 /**
- * Find shortest path between two records
+ * Find shortest path between two records.
+ *
+ * Pass `conditions` (a raw SurrealQL predicate) to filter the path records.
  */
 export async function shortestPath(
   db: Surreal,
   from: string,
   to: string,
   edge: string,
-  maxDepth: number = 10,
+  maxDepth?: number,
+  conditions?: string,
 ): Promise<Record<string, unknown>[]> {
   validateIdentifier(edge)
   try {
+    const depth = maxDepth ?? 10
     const sql = `SELECT * FROM fn::graph::shortest_path(${quoteValue(from)}, ${quoteValue(to)}, ${
       quoteValue(edge)
-    }, ${maxDepth})`
+    }, ${depth})${whereClause(conditions)}`
     const results = await db.query<Record<string, unknown>[]>(sql) as unknown as Record<string, unknown>[][]
     return results[0] || []
   } catch (e) {

--- a/src/query/helpers.ts
+++ b/src/query/helpers.ts
@@ -1,3 +1,5 @@
+import { RecordId } from 'surrealdb'
+
 /**
  * Return format for query results
  */
@@ -15,12 +17,40 @@ export enum ReturnFormat {
 export type VectorDistanceType = 'COSINE' | 'EUCLIDEAN' | 'MANHATTAN' | 'MINKOWSKI' | 'CHEBYSHEV' | 'HAMMING'
 
 /**
+ * Escape a string for embedding inside single quotes in SurrealQL.
+ *
+ * Backslashes are escaped first, then single quotes, so an attacker can't
+ * smuggle a closing quote via `\'` (CodeQL js/incomplete-sanitization).
+ */
+function escapeString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+}
+
+/**
+ * Render an object key for a SurrealQL object literal. A bare identifier is
+ * emitted verbatim; anything else is single-quoted.
+ */
+function quoteKey(key: string): string {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(key) ? key : `'${escapeString(key)}'`
+}
+
+/**
  * Quote a value for safe SurrealQL embedding.
- * Values with a `__surqlFn` marker are rendered as raw SurrealQL (server-side functions).
+ *
+ * - `null` / `undefined` render as `NONE` (the absence of a value).
+ * - Values carrying a `__surqlFn` marker render as raw SurrealQL — server-side
+ *   functions such as `time::now()`.
+ * - `RecordId` instances render as a record-id literal (e.g. `user:alice`).
+ * - `Date` instances render as a SurrealQL datetime literal (`d'...'`); a bare
+ *   quoted string is rejected by v3 datetime-typed fields.
+ * - Arrays and plain objects render as SurrealQL array / object literals,
+ *   recursing through `quoteValue` so a nested record id, datetime, or
+ *   function marker is rendered correctly instead of being flattened into a
+ *   JSON string (which would emit, e.g., a literal `{"__surqlFn":true,...}`).
  */
 export function quoteValue(value: unknown): string {
   if (value === null || value === undefined) return 'NONE'
-  // Handle SurrealFnValue - render as raw SurrealQL, not parameterized
+  // SurrealFnValue — render as raw SurrealQL, not a parameterized value.
   if (
     typeof value === 'object' &&
     value !== null &&
@@ -30,16 +60,16 @@ export function quoteValue(value: unknown): string {
   ) {
     return (value as { surql: string }).surql
   }
-  if (typeof value === 'string') {
-    // Escape backslashes first, then single quotes, so that an attacker
-    // can't smuggle a closing quote via `\'` (CodeQL js/incomplete-sanitization).
-    const escaped = value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
-    return `'${escaped}'`
-  }
+  if (typeof value === 'string') return `'${escapeString(value)}'`
   if (typeof value === 'boolean') return value ? 'true' : 'false'
   if (typeof value === 'number') return String(value)
+  if (value instanceof RecordId) return value.toString()
+  if (value instanceof Date) return `d'${value.toISOString()}'`
   if (Array.isArray(value)) return `[${value.map(quoteValue).join(', ')}]`
-  if (typeof value === 'object') return JSON.stringify(value)
+  if (typeof value === 'object') {
+    const entries = Object.entries(value).map(([k, v]) => `${quoteKey(k)}: ${quoteValue(v)}`)
+    return entries.length > 0 ? `{ ${entries.join(', ')} }` : '{}'
+  }
   return String(value)
 }
 

--- a/src/schema/fields.ts
+++ b/src/schema/fields.ts
@@ -30,6 +30,12 @@ export interface FieldDefinition {
   readonly value?: string
   readonly readonly?: boolean
   readonly flexible?: boolean
+  /**
+   * Emit the field type wrapped as `option<...>` so a SCHEMAFULL column
+   * accepts the absence of a value (NONE). Without it, every record that
+   * omits the column is rejected on v3 with a coercion error.
+   */
+  readonly optional?: boolean
   readonly permissions?: FieldPermissions
 }
 

--- a/src/schema/sql.ts
+++ b/src/schema/sql.ts
@@ -27,14 +27,24 @@ function permissionsClause(
   return clauses.length > 0 ? ` PERMISSIONS ${clauses.join(' ')}` : ''
 }
 
-function fieldTypeToSql(field: FieldDefinition): string {
+/**
+ * Render a field's SurrealQL type. A record link emits `record<target>` and
+ * an array element type emits `array<T>`; an `optional` field wraps the whole
+ * type as `option<...>` so a SCHEMAFULL column accepts NONE.
+ *
+ * Exported so the migration differ renders field types identically to the
+ * initial schema generator.
+ */
+export function fieldTypeToSql(field: FieldDefinition): string {
+  let type: string
   if (field.type === FieldType.RECORD && field.recordLink) {
-    return `record<${field.recordLink}>`
+    type = `record<${field.recordLink}>`
+  } else if (field.type === FieldType.ARRAY && field.arrayType) {
+    type = `array<${field.arrayType}>`
+  } else {
+    type = field.type
   }
-  if (field.type === FieldType.ARRAY && field.arrayType) {
-    return `array<${field.arrayType}>`
-  }
-  return field.type
+  return field.optional ? `option<${type}>` : type
 }
 
 function generateFieldSql(tableName: string, field: FieldDefinition): string {

--- a/src/schema/sql.ts
+++ b/src/schema/sql.ts
@@ -6,6 +6,27 @@ import type { EdgeDefinition } from './edge.ts'
 import type { EventDefinition, IndexDefinition, TableDefinition } from './table.ts'
 import { IndexType } from './table.ts'
 
+/**
+ * Render a `PERMISSIONS` clause for a `DEFINE TABLE`, `DEFINE FIELD`, or
+ * relation statement.
+ *
+ * Each configured action contributes a `FOR <action>` sub-clause; the
+ * SurrealDB v3 grammar folds them all into the owning statement, separated
+ * by whitespace. The returned string carries a leading space (or is empty
+ * when no permissions are set) so callers can append it unconditionally.
+ */
+function permissionsClause(
+  perms: { select?: string; create?: string; update?: string; delete?: string } | undefined,
+): string {
+  if (!perms) return ''
+  const clauses: string[] = []
+  if (perms.select) clauses.push(`FOR select ${perms.select}`)
+  if (perms.create) clauses.push(`FOR create ${perms.create}`)
+  if (perms.update) clauses.push(`FOR update ${perms.update}`)
+  if (perms.delete) clauses.push(`FOR delete ${perms.delete}`)
+  return clauses.length > 0 ? ` PERMISSIONS ${clauses.join(' ')}` : ''
+}
+
 function fieldTypeToSql(field: FieldDefinition): string {
   if (field.type === FieldType.RECORD && field.recordLink) {
     return `record<${field.recordLink}>`
@@ -38,16 +59,7 @@ function generateFieldSql(tableName: string, field: FieldDefinition): string {
   if (field.readonly) {
     parts[0] += ' READONLY'
   }
-  if (field.permissions) {
-    const perms: string[] = []
-    if (field.permissions.select) perms.push(`FOR select ${field.permissions.select}`)
-    if (field.permissions.create) perms.push(`FOR create ${field.permissions.create}`)
-    if (field.permissions.update) perms.push(`FOR update ${field.permissions.update}`)
-    if (field.permissions.delete) perms.push(`FOR delete ${field.permissions.delete}`)
-    if (perms.length > 0) {
-      parts[0] += ` PERMISSIONS ${perms.join(', ')}`
-    }
-  }
+  parts[0] += permissionsClause(field.permissions)
 
   return parts[0] + ';'
 }
@@ -88,16 +100,20 @@ function generateEventSql(tableName: string, evt: EventDefinition): string {
 /**
  * Generate SurrealQL DDL for a table definition.
  *
+ * Table-level permissions are folded into the single `DEFINE TABLE`
+ * statement. They must NOT be emitted as a second `DEFINE TABLE` line: on
+ * SurrealDB v3 a repeat `DEFINE TABLE` for an existing table fails with
+ * `The table '<name>' already exists`, and even where it parsed it would
+ * redefine the table — silently dropping its `SCHEMAFULL`/`SCHEMALESS` mode.
+ *
  * Pass `ifNotExists: true` to emit `DEFINE TABLE IF NOT EXISTS ...` so the
- * statement is idempotent against an existing schema. The flag also applies
- * to the secondary `DEFINE TABLE ... PERMISSIONS` line when table-level
- * permissions are configured.
+ * statement is idempotent against an existing schema.
  */
 export function generateTableSql(table: TableDefinition, options: { ifNotExists?: boolean } = {}): string {
   const ine = options.ifNotExists ? ' IF NOT EXISTS' : ''
   const lines: string[] = []
 
-  lines.push(`DEFINE TABLE${ine} ${table.name} ${table.mode};`)
+  lines.push(`DEFINE TABLE${ine} ${table.name} ${table.mode}${permissionsClause(table.permissions)};`)
 
   for (const field of table.fields) {
     lines.push(generateFieldSql(table.name, field))
@@ -111,22 +127,15 @@ export function generateTableSql(table: TableDefinition, options: { ifNotExists?
     lines.push(generateEventSql(table.name, evt))
   }
 
-  if (table.permissions) {
-    const perms: string[] = []
-    if (table.permissions.select) perms.push(`FOR select ${table.permissions.select}`)
-    if (table.permissions.create) perms.push(`FOR create ${table.permissions.create}`)
-    if (table.permissions.update) perms.push(`FOR update ${table.permissions.update}`)
-    if (table.permissions.delete) perms.push(`FOR delete ${table.permissions.delete}`)
-    if (perms.length > 0) {
-      lines.push(`DEFINE TABLE${ine} ${table.name} PERMISSIONS ${perms.join(', ')};`)
-    }
-  }
-
   return lines.join('\n')
 }
 
 /**
  * Generate SurrealQL DDL for an edge definition.
+ *
+ * Edge permissions are folded into the relation's `DEFINE TABLE` statement;
+ * an edge built with `withEdgePermissions(...)` previously had its
+ * permissions silently dropped.
  *
  * Pass `ifNotExists: true` to emit `DEFINE TABLE IF NOT EXISTS ... TYPE RELATION`
  * for idempotent schema application.
@@ -138,6 +147,7 @@ export function generateEdgeSql(edge: EdgeDefinition, options: { ifNotExists?: b
   let tableDef = `DEFINE TABLE${ine} ${edge.name} TYPE ${edge.mode}`
   if (edge.fromTable) tableDef += ` FROM ${edge.fromTable}`
   if (edge.toTable) tableDef += ` TO ${edge.toTable}`
+  tableDef += permissionsClause(edge.permissions)
   lines.push(tableDef + ';')
 
   for (const field of edge.fields) {

--- a/src/test/diff_extended.test.ts
+++ b/src/test/diff_extended.test.ts
@@ -1,6 +1,6 @@
-import { assertEquals } from '@std/assert'
+import { assertEquals, assertExists, assertStringIncludes } from '@std/assert'
 import { describe, it } from '@std/testing/bdd'
-import { diffEdges, diffPermissions } from '../migration/diff.ts'
+import { diffEdges, diffPermissions, diffTables } from '../migration/diff.ts'
 import { DiffOperation } from '../migration/models.ts'
 import {
   EdgeMode,
@@ -9,9 +9,11 @@ import {
   withEdgeFields,
   withEdgeIndexes,
   withEdgePermissions,
+  withFromTable,
+  withToTable,
 } from '../schema/edge.ts'
-import { intField, stringField } from '../schema/fields.ts'
-import { event, index, TableMode, tableSchema, withPermissions } from '../schema/table.ts'
+import { intField, recordField, stringField } from '../schema/fields.ts'
+import { event, index, TableMode, tableSchema, withFields, withPermissions } from '../schema/table.ts'
 import type { TableDefinition } from '../schema/table.ts'
 
 describe('diffPermissions', () => {
@@ -240,5 +242,59 @@ describe('diffEdges', () => {
     assertEquals(diffs.length, 1)
     assertEquals(diffs[0].operation, DiffOperation.DROP_INDEX)
     assertEquals(diffs[0].table, 'likes')
+  })
+})
+
+describe('diff field-type rendering', () => {
+  it('should render a record link as record<target> in an ADD_FIELD diff', () => {
+    const current = [tableSchema('posts')]
+    const target = [withFields(tableSchema('posts'), recordField('author', 'users'))]
+    const addField = diffTables(current, target).find((d) => d.operation === DiffOperation.ADD_FIELD)
+    assertExists(addField)
+    assertStringIncludes(addField.sql, 'TYPE record<users>;')
+  })
+
+  it('should render an optional field as option<X> in an ADD_FIELD diff', () => {
+    const current = [tableSchema('users')]
+    const target = [withFields(tableSchema('users'), stringField('bio', { optional: true }))]
+    const addField = diffTables(current, target).find((d) => d.operation === DiffOperation.ADD_FIELD)
+    assertExists(addField)
+    assertStringIncludes(addField.sql, 'TYPE option<string>;')
+  })
+
+  it('should detect a changed record link as a MODIFY_FIELD', () => {
+    const current = [withFields(tableSchema('posts'), recordField('author', 'users'))]
+    const target = [withFields(tableSchema('posts'), recordField('author', 'accounts'))]
+    const modify = diffTables(current, target).find((d) => d.operation === DiffOperation.MODIFY_FIELD)
+    assertExists(modify)
+    assertStringIncludes(modify.sql, 'TYPE record<accounts>;')
+  })
+
+  it('should emit a new table’s fields and permissions in the ADD_TABLE diff', () => {
+    const target = [
+      withFields(
+        withPermissions(tableSchema('users'), { select: 'FULL' }),
+        stringField('name'),
+        recordField('manager', 'users', { optional: true }),
+      ),
+    ]
+    const diffs = diffTables([], target)
+    // A new table is still a single ADD_TABLE diff — the full DDL is its sql.
+    assertEquals(diffs.length, 1)
+    assertEquals(diffs[0].operation, DiffOperation.ADD_TABLE)
+    assertStringIncludes(diffs[0].sql, 'DEFINE TABLE users SCHEMAFULL PERMISSIONS FOR select FULL;')
+    assertStringIncludes(diffs[0].sql, 'DEFINE FIELD name ON TABLE users TYPE string;')
+    assertStringIncludes(diffs[0].sql, 'DEFINE FIELD manager ON TABLE users TYPE option<record<users>>;')
+  })
+
+  it('should emit a new edge’s FROM/TO and fields in the ADD_TABLE diff', () => {
+    const newEdge = withEdgeFields(
+      withToTable(withFromTable(edgeSchema('wrote', EdgeMode.RELATION), 'users'), 'posts'),
+      stringField('at'),
+    )
+    const diffs = diffEdges(null, newEdge)
+    assertEquals(diffs.length, 1)
+    assertStringIncludes(diffs[0].sql, 'DEFINE TABLE wrote TYPE RELATION FROM users TO posts;')
+    assertStringIncludes(diffs[0].sql, 'DEFINE FIELD at ON TABLE wrote TYPE string;')
   })
 })

--- a/src/test/graph.test.ts
+++ b/src/test/graph.test.ts
@@ -328,3 +328,54 @@ describe('findMutualConnections', () => {
     )
   })
 })
+
+describe('graph helpers with WHERE conditions', () => {
+  it('traverse appends a WHERE clause', async () => {
+    // deno-lint-ignore no-explicit-any
+    const db = makeMockDb([[]]) as any
+    await traverse(db, 'users:1', '->follows->users', 'age > 18')
+    assertEquals(db.queries[0], 'SELECT * FROM users:1.->follows->users WHERE age > 18')
+  })
+
+  it('traverseWithDepth appends a WHERE clause', async () => {
+    // deno-lint-ignore no-explicit-any
+    const db = makeMockDb([[]]) as any
+    await traverseWithDepth(db, 'users:1', 'follows', '->', 2, 'active = true')
+    assertEquals(db.queries[0], 'SELECT * FROM users:1->follows->follows.* WHERE active = true')
+  })
+
+  it('getRelatedRecords appends a WHERE clause', async () => {
+    // deno-lint-ignore no-explicit-any
+    const db = makeMockDb([[]]) as any
+    await getRelatedRecords(db, 'users:1', 'follows', '->', "tenant = 'acme'")
+    assertEquals(db.queries[0], "SELECT * FROM users:1->follows.* WHERE tenant = 'acme'")
+  })
+
+  it('getOutgoingEdges appends a WHERE clause', async () => {
+    // deno-lint-ignore no-explicit-any
+    const db = makeMockDb([[]]) as any
+    await getOutgoingEdges(db, 'users:1', 'follows', 'weight > 0')
+    assertEquals(db.queries[0], 'SELECT * FROM users:1->follows WHERE weight > 0')
+  })
+
+  it('getIncomingEdges appends a WHERE clause', async () => {
+    // deno-lint-ignore no-explicit-any
+    const db = makeMockDb([[]]) as any
+    await getIncomingEdges(db, 'users:1', 'follows', 'weight > 0')
+    assertEquals(db.queries[0], 'SELECT * FROM users:1<-follows WHERE weight > 0')
+  })
+
+  it('shortestPath appends a WHERE clause', async () => {
+    // deno-lint-ignore no-explicit-any
+    const db = makeMockDb([[]]) as any
+    await shortestPath(db, 'users:1', 'users:5', 'follows', 5, 'cost < 100')
+    assertEquals(db.queries[0].endsWith(' WHERE cost < 100'), true)
+  })
+
+  it('omits the WHERE clause when no conditions are given', async () => {
+    // deno-lint-ignore no-explicit-any
+    const db = makeMockDb([[]]) as any
+    await traverse(db, 'users:1', '->follows->users')
+    assertEquals(db.queries[0].includes('WHERE'), false)
+  })
+})

--- a/src/test/helpers.test.ts
+++ b/src/test/helpers.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertThrows } from '@std/assert'
 import { describe, it } from '@std/testing/bdd'
+import { RecordId } from 'surrealdb'
 import { escapeTable, quoteValue, ReturnFormat, validateIdentifier } from '../query/helpers.ts'
 
 describe('quoteValue', () => {
@@ -48,9 +49,44 @@ describe('quoteValue', () => {
     assertEquals(quoteValue([[1, 2], [3]]), '[[1, 2], [3]]')
   })
 
-  it('should JSON.stringify plain objects', () => {
-    const result = quoteValue({ key: 'val' })
-    assertEquals(result, '{"key":"val"}')
+  it('should format plain objects as SurrealQL object literals', () => {
+    assertEquals(quoteValue({ key: 'val' }), "{ key: 'val' }")
+    assertEquals(quoteValue({ a: 1, b: true }), '{ a: 1, b: true }')
+  })
+
+  it('should handle empty objects', () => {
+    assertEquals(quoteValue({}), '{}')
+  })
+
+  it('should single-quote object keys that are not bare identifiers', () => {
+    assertEquals(quoteValue({ 'weird-key': 1 }), "{ 'weird-key': 1 }")
+  })
+
+  it('should recurse through nested objects and arrays', () => {
+    assertEquals(
+      quoteValue({ tags: ['x', 'y'], meta: { n: 2 } }),
+      "{ tags: ['x', 'y'], meta: { n: 2 } }",
+    )
+  })
+
+  it('should render RecordId values as record-id literals', () => {
+    assertEquals(quoteValue(new RecordId('user', 'alice')), 'user:alice')
+    // The SDK brackets ids that contain non-bare characters.
+    assertEquals(quoteValue(new RecordId('community', 'lakewood-village')), 'community:⟨lakewood-village⟩')
+  })
+
+  it('should render a RecordId nested inside an object', () => {
+    assertEquals(quoteValue({ author: new RecordId('user', 'bob') }), '{ author: user:bob }')
+  })
+
+  it('should render Date values as SurrealQL datetime literals', () => {
+    assertEquals(quoteValue(new Date('2026-05-17T12:00:00.000Z')), "d'2026-05-17T12:00:00.000Z'")
+  })
+
+  it('should render a nested SurrealFnValue as raw SurrealQL, not a JSON object', () => {
+    const fn = { __surqlFn: true, surql: 'time::now()' }
+    assertEquals(quoteValue({ created: fn }), '{ created: time::now() }')
+    assertEquals(quoteValue([fn]), '[time::now()]')
   })
 
   it('should handle empty arrays', () => {

--- a/src/test/schema.test.ts
+++ b/src/test/schema.test.ts
@@ -23,6 +23,7 @@ import {
   uniqueIndex,
   validateSchema,
   withEdgeFields,
+  withEdgePermissions,
   withEvents,
   withFields,
   withFromTable,
@@ -167,13 +168,50 @@ describe('Schema System', () => {
       assertEquals(sql.includes('IF NOT EXISTS'), false)
     })
 
-    it('should apply IF NOT EXISTS to the secondary permissions DEFINE TABLE line', () => {
+    it('should fold table permissions into the single DEFINE TABLE statement', () => {
+      const t = withPermissions(tableSchema('users'), {
+        select: 'WHERE user = $auth.id',
+        create: 'FULL',
+      })
+      const sql = generateTableSql(t)
+      // Exactly ONE DEFINE TABLE for the table — a repeat DEFINE TABLE errors
+      // on SurrealDB v3 and would drop the SCHEMAFULL mode.
+      assertEquals((sql.match(/DEFINE TABLE users/g) ?? []).length, 1)
+      assertStringIncludes(
+        sql,
+        'DEFINE TABLE users SCHEMAFULL PERMISSIONS FOR select WHERE user = $auth.id FOR create FULL;',
+      )
+    })
+
+    it('should apply IF NOT EXISTS exactly once to a table with permissions', () => {
       const t = withPermissions(tableSchema('users'), { select: 'WHERE user = $auth' })
       const sql = generateTableSql(t, { ifNotExists: true })
-      // Both the primary and the permissions line must carry IF NOT EXISTS.
-      const occurrences = sql.match(/DEFINE TABLE IF NOT EXISTS users/g) ?? []
-      assertEquals(occurrences.length, 2)
-      assertStringIncludes(sql, 'PERMISSIONS FOR select WHERE user = $auth')
+      assertEquals((sql.match(/DEFINE TABLE IF NOT EXISTS users/g) ?? []).length, 1)
+      assertStringIncludes(sql, 'SCHEMAFULL PERMISSIONS FOR select WHERE user = $auth')
+    })
+
+    it('should emit edge permissions on the relation DEFINE TABLE', () => {
+      const e = withEdgePermissions(
+        withToTable(withFromTable(edgeSchema('follows'), 'users'), 'users'),
+        { select: 'WHERE in = $auth.id', delete: 'NONE' },
+      )
+      const sql = generateEdgeSql(e)
+      assertStringIncludes(
+        sql,
+        'DEFINE TABLE follows TYPE RELATION FROM users TO users PERMISSIONS FOR select WHERE in = $auth.id FOR delete NONE;',
+      )
+    })
+
+    it('should fold field permissions into the DEFINE FIELD statement', () => {
+      const t = withFields(
+        tableSchema('users'),
+        stringField('email', { permissions: { select: 'FULL', update: 'WHERE user = $auth.id' } }),
+      )
+      const sql = generateTableSql(t)
+      assertStringIncludes(
+        sql,
+        'DEFINE FIELD email ON TABLE users TYPE string PERMISSIONS FOR select FULL FOR update WHERE user = $auth.id;',
+      )
     })
 
     it('should emit DEFINE TABLE IF NOT EXISTS ... TYPE RELATION for edges', () => {

--- a/src/test/schema.test.ts
+++ b/src/test/schema.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertStringIncludes } from '@std/assert'
 import { afterEach, describe, it } from '@std/testing/bdd'
 import {
+  arrayField,
   clearRegistry,
   EdgeMode,
   edgeSchema,
@@ -122,6 +123,24 @@ describe('Schema System', () => {
       assertStringIncludes(sql, 'DEFINE TABLE users SCHEMAFULL')
       assertStringIncludes(sql, 'DEFINE FIELD name ON TABLE users TYPE string')
       assertStringIncludes(sql, 'DEFINE FIELD age ON TABLE users TYPE int')
+    })
+
+    it('should emit option<X> for an optional field', () => {
+      const t = withFields(tableSchema('users'), stringField('bio', { optional: true }))
+      const sql = generateTableSql(t)
+      assertStringIncludes(sql, 'DEFINE FIELD bio ON TABLE users TYPE option<string>')
+    })
+
+    it('should wrap a record link as option<record<...>> when optional', () => {
+      const t = withFields(tableSchema('posts'), recordField('author', 'users', { optional: true }))
+      const sql = generateTableSql(t)
+      assertStringIncludes(sql, 'DEFINE FIELD author ON TABLE posts TYPE option<record<users>>')
+    })
+
+    it('should wrap an array element type as option<array<...>> when optional', () => {
+      const t = withFields(tableSchema('posts'), arrayField('tags', FieldType.STRING, { optional: true }))
+      const sql = generateTableSql(t)
+      assertStringIncludes(sql, 'DEFINE FIELD tags ON TABLE posts TYPE option<array<string>>')
     })
 
     it('should generate index DDL', () => {

--- a/src/test/transaction.test.ts
+++ b/src/test/transaction.test.ts
@@ -2,24 +2,49 @@ import { assertEquals, assertRejects, assertStringIncludes } from '@std/assert'
 import { describe, it } from '@std/testing/bdd'
 import { Transaction, TransactionState } from '../connection/transaction.ts'
 
-function mockDb() {
+/** One per-statement entry, mirroring the SDK's `query(...).responses()` shape. */
+type Resp = {
+  success: boolean
+  result?: unknown
+  error?: { kind?: string; details?: { kind?: string } | null }
+}
+
+/** Count the `;`-separated statements in a flushed BEGIN/COMMIT batch. */
+function countStatements(sql: string): number {
+  return sql.split(';').map((s) => s.trim()).filter((s) => s.length > 0).length
+}
+
+/**
+ * Mock connection whose `query()` returns a Query-like object exposing
+ * `.responses()` — the accessor `Transaction.commit()` now uses. Without an
+ * override every statement reports success; `result` is its 0-based index.
+ */
+function mockDb(makeEnvelope?: (sql: string) => Resp[]) {
   const queries: string[] = []
   return {
     queries,
     query: (sql: string) => {
       queries.push(sql)
-      return Promise.resolve([])
+      return {
+        responses: () =>
+          Promise.resolve(
+            makeEnvelope
+              ? makeEnvelope(sql)
+              : Array.from({ length: countStatements(sql) }, (_, i): Resp => ({ success: true, result: i })),
+          ),
+      }
     },
   }
 }
 
+/** Mock connection whose `.responses()` rejects — simulates a transport failure. */
 function failingDb(err: Error) {
   const queries: string[] = []
   return {
     queries,
     query: (sql: string) => {
       queries.push(sql)
-      return Promise.reject(err)
+      return { responses: () => Promise.reject(err) }
     },
   }
 }
@@ -193,6 +218,67 @@ describe('Transaction', () => {
     await tx.begin()
     await tx.execute('SELECT 1')
     await assertRejects(() => tx.commit(), Error, 'Failed to commit transaction')
+    assertEquals(tx.state, TransactionState.FAILED)
+  })
+
+  it('should return the queued statements’ results, in order, from commit()', async () => {
+    // Envelope: BEGIN, statement 1, statement 2, COMMIT.
+    const db = mockDb((sql) => {
+      const n = countStatements(sql)
+      return Array.from({ length: n }, (_, i): Resp => ({
+        success: true,
+        result: i === 0 ? 'BEGIN' : i === n - 1 ? 'COMMIT' : [`row-${i}`],
+      }))
+    })
+    // deno-lint-ignore no-explicit-any
+    const tx = new Transaction(db as any)
+    await tx.begin()
+    await tx.execute('CREATE a SET n = 1')
+    await tx.execute('CREATE b SET n = 2')
+    const results = await tx.commit()
+    // BEGIN / COMMIT bookends stripped; only the two user statements remain.
+    assertEquals(results, [['row-1'], ['row-2']])
+  })
+
+  it('should return an empty array from commit() when nothing was queued', async () => {
+    const db = mockDb()
+    // deno-lint-ignore no-explicit-any
+    const tx = new Transaction(db as any)
+    await tx.begin()
+    assertEquals(await tx.commit(), [])
+  })
+
+  it('should throw and mark FAILED when a statement rolls the batch back', async () => {
+    // BEGIN ok; statement 1 rolled back (NotExecuted cascade); statement 2 threw.
+    const db = mockDb(() => [
+      { success: true },
+      { success: false, error: { kind: 'Query', details: { kind: 'NotExecuted' } } },
+      { success: false, error: { kind: 'Thrown' } },
+    ])
+    // deno-lint-ignore no-explicit-any
+    const tx = new Transaction(db as any)
+    await tx.begin()
+    await tx.execute('CREATE a SET n = 1')
+    await tx.execute("THROW 'boom'")
+    // The cascade entry is skipped; the originating failure is named instead.
+    await assertRejects(
+      () => tx.commit(),
+      Error,
+      'statement 2 of 2 failed (Thrown)',
+    )
+    assertEquals(tx.state, TransactionState.FAILED)
+  })
+
+  it('should distinguish a BEGIN-level failure in the rollback message', async () => {
+    const db = mockDb(() => [
+      { success: false, error: { kind: 'Db' } },
+      { success: false, error: { kind: 'Query', details: { kind: 'NotExecuted' } } },
+    ])
+    // deno-lint-ignore no-explicit-any
+    const tx = new Transaction(db as any)
+    await tx.begin()
+    await tx.execute('SELECT 1')
+    await assertRejects(() => tx.commit(), Error, 'the BEGIN statement failed (Db)')
     assertEquals(tx.state, TransactionState.FAILED)
   })
 })


### PR DESCRIPTION
## Summary

surql **v1.4.0** — a single release bundling SurrealDB v3 correctness fixes,
schema/query parity additions, a documentation-accuracy fix, and CI hardening.

It supersedes the prepared-but-never-tagged **v1.3.5** — that release's docs +
CI work is folded in here — and replaces PR #61.

## Fixed

- **`Transaction.commit()` discarded the per-statement results.**
  `Transaction.execute()` documents that the results become available from
  `commit()`, but `commit()` returned `void`. It now flushes the
  `BEGIN ...; COMMIT` batch through the SDK's `query(...).responses()`
  accessor: it returns the queued statements' results in order, confirms the
  batch actually committed, and — on a rollback — names the statement that
  caused it instead of a generic "failed transaction".
- **Table and edge `PERMISSIONS` produced un-runnable DDL.**
  `generateTableSql` emitted permissions as a *second* `DEFINE TABLE`
  statement; on SurrealDB v3 a repeat `DEFINE TABLE` for an existing table
  fails (`The table '<name>' already exists`), and otherwise drops the table's
  `SCHEMAFULL`/`SCHEMALESS` mode. `generateEdgeSql` ignored edge permissions
  entirely. Both now fold permissions into the single `DEFINE TABLE`.
- **`quoteValue()` flattened objects, RecordIds, and Dates with
  `JSON.stringify`** — a nested function marker, record id, or date became a
  JSON blob rather than SurrealQL. It now emits SurrealQL object literals
  (recursively), record-id literals, and `d'...'` datetime literals.
- **The migration differ emitted incomplete, mistyped DDL** — `ADD_FIELD` /
  `MODIFY_FIELD` dropped `record<target>`, array element types, and
  `option<...>`; `ADD_TABLE` for a new table emitted only
  `DEFINE TABLE name mode;`, creating an empty table. Diffs now render the
  full field type and a new table/edge's complete DDL.
- **Docs**: the migration docs imported and called APIs that surql does not
  export (`diffSchemas`, `MigrationRunner`, `RollbackManager`, and others).
  Every example is rewritten against the real exported API. Closes #62.

## Added

- **Optional fields** — `FieldDefinition.optional` emits `option<...>`
  (`option<string>`, `option<record<user>>`, ...) so a SCHEMAFULL column
  accepts the absence of a value.
- **WHERE filtering on graph helpers** — `traverse`, `traverseWithDepth`,
  `getRelatedRecords`, `getOutgoingEdges`, `getIncomingEdges`, and
  `shortestPath` accept an optional `conditions` predicate.

## CI

Hardened the workflow set so runs stop stalling. `docs.yml`'s global `pages`
concurrency group — which serialised every build and deploy across all refs
behind one queue, the cause of the multi-day stalls on PR #61 — is now keyed
per-ref. `integration` and `audit` run as PR gates on `ubuntu-latest`
(previously manual-only); per-ref concurrency groups were added to the
auto-merge / PR-title / dependency-review workflows; pinned action versions
were bumped. Absorbs dependabot PRs #56–#60. Closes #40.

## Verification

- `deno fmt --check`, `deno lint`, `deno check` — clean.
- Full unit suite — **189 files, 1697 steps, 0 failed**.
- `mkdocs build --strict` — clean.
- The v3 grammar paths (transaction rollback envelopes,
  `DEFINE TABLE ... PERMISSIONS`, `option<...>`, datetime/object literals)
  were verified against a live SurrealDB v3.0.5.

## Releasing

This is a curated commit series — merge with a merge commit (not squash), then
tag `v1.4.0` and publish a GitHub Release to trigger the publish workflow.
