### PR TITLE
chore(release): v1.5.0 — parseEdgeInfo upgrades, stripBrackets, tx-bound upsertMany

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [1.5.0] - 2026-05-19
+
+### Added
+
+- **Edge round-trip parity in the schema parser** (`parseEdgeInfo`): edges defined via `edgeSchema` / `EdgeDefinition` now round-trip through `parseEdgeInfo` with the same fidelity tables already had. Edge mode is detected from the `DEFINE TABLE` statement — `TYPE RELATION` resolves to `EdgeMode.RELATION`, `SCHEMAFULL` to `EdgeMode.SCHEMAFULL`, anything else to `EdgeMode.SCHEMALESS` — so SCHEMAFULL edges no longer collapse into the RELATION case. `FROM <table>` and `TO <table>` are parsed independently so a malformed live definition that lost one clause surfaces as missing-endpoint drift instead of a parse failure. On `TYPE RELATION` edges the auto-emitted `in` and `out` fields SurrealDB stores are stripped on parse — they are implicit when `TYPE RELATION` is set, so the code-side `EdgeDefinition` does not declare them and round-trip diffs were flagging them as orphan additions. Per-action `PERMISSIONS` (including the comma-joined `FOR select, create, update, delete WHERE …` shape v3 emits) round-trip via the existing `parseTablePermissions` helper.
+- **`stripBrackets(value)` helper** in `src/utils/helpers.ts`, also re-exported from the package root. SurrealDB v3 wraps record-id keys that contain anything other than `[a-zA-Z_][a-zA-Z0-9_]*` or pure digits in unicode angle brackets `⟨ … ⟩` (U+27E8 / U+27E9). Downstream consumers that wanted the bare `table:id` wire shape were calling `value.replace('⟨', '').replace('⟩', '')` themselves at every API boundary; `stripBrackets` centralises that strip and also accepts the legacy ASCII `< … >` form, so consumers can drop their own ad-hoc `.replace` calls. `null` and `undefined` are passed through untouched so the helper is safe to apply unconditionally. `recordIdToString` now delegates to `stripBrackets`, picking up ASCII-bracket handling as a side benefit.
+- **Transaction-bound `upsertMany`**: the `client` argument now accepts either a `Surreal` connection (autocommit, legacy behaviour) or an active `Transaction` (atomic). In the transaction mode the same per-record `UPSERT … CONTENT { … }` statements are queued on the supplied transaction via `trx.execute`, inheriting the surrounding `BEGIN TRANSACTION` / `COMMIT TRANSACTION` framing so a single bad record rolls the *entire* batch back on commit instead of leaving the database half-seeded. The mode is auto-detected — no call-site rewrite is needed beyond passing the transaction handle. Results are not available at call time in transaction mode (`Transaction.execute` buffers); the per-row results land in `Transaction.commit()`'s return value. `upsertMany` also gains an optional `conflictFields` parameter (matching the surql-py port) — fields in this list are emitted as a `WHERE field = value AND …` clause appended to each UPSERT. The conflict values are inlined rather than parameterised because `Transaction.execute` does not bind params.
+
+### Fixed
+
+- **`buildUpsertQuery` emitted `UPSERT INTO <table> [ {…}, {…} ]` which SurrealDB v3 rejects with a parse error.** The function now emits one `UPSERT <target> CONTENT { … }` statement per item — the v3-correct per-record shape used across the surql-py / surql-rs / surql-go ports — joined by `;`. Items with an `id` field are upserted by record id; items without one are upserted into the table. The `conflictFields` parameter (when supplied) now emits inline-value WHERE clauses (`WHERE email = 'a@b.com'`) instead of the previous `$item.email` placeholder shape, because the per-statement query has no `$item` binding in scope.
+- **`upsertMany` ran one round-trip RPC per record.** The function now batches all per-record `UPSERT … CONTENT { … }` statements into a single multi-statement query in autocommit mode, reducing N records from N RPCs to 1 RPC and matching surql-py's autocommit behaviour. Records returned by the server are concatenated across the per-statement result envelopes so the caller still gets one row per upsert.
+- **`upsertMany` did not honour the `id` field as the UPSERT target.** Previously every record landed via a table-level `UPSERT <table> SET k = v` regardless of whether the input declared `id: 'users:alice'`. The per-record target is now `data.id` when present (so `{id: 'users:alice', name: 'Alice'}` becomes `UPSERT users:alice CONTENT { name: 'Alice' }`) and falls back to the bare table otherwise. The `id` field is stripped from the CONTENT payload to avoid double-writing.
+
+### Verified
+
+- `deno fmt --check src/` — clean.
+- `deno lint src/` — clean.
+- `deno check src/cli/main.ts src/cli/mod.ts mod.ts` — clean.
+- `deno task test --ignore='src/test/integration*.test.ts'` — **199 passed (1752 steps), 0 failed** (was 195 / 1712 on 1.4.0; +40 regression-test steps covering the three new features and the two query-shape fixes).
+
+### Housekeeping
+
+- Version bumped to `1.5.0` in `deno.json`.
+
+---
+
 ## [1.4.0] - 2026-05-17
 
 ### Added

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "lock": true,
   "name": "@oneiriq/surql",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "license": "Apache-2.0",
   "exports": {
     ".": "./mod.ts",

--- a/src/query/batch.ts
+++ b/src/query/batch.ts
@@ -1,4 +1,6 @@
 import type { Surreal } from 'surrealdb'
+import { Transaction } from '../connection/transaction.ts'
+import { TransactionError } from '../connection/errors.ts'
 import { intoSurQlError } from '../utils/surrealError.ts'
 import { escapeTable, quoteValue, validateIdentifier } from './helpers.ts'
 
@@ -28,27 +30,159 @@ export async function insertMany<T = Record<string, unknown>>(
 }
 
 /**
- * Batch upsert multiple records
+ * Render an `item` dict as a SurrealQL object literal — `{ key: value, ... }`.
+ * Field names are validated; values are run through {@link quoteValue} so
+ * `RecordId`, `Date`, nested objects, and arrays all emit as native SurrealQL
+ * shapes rather than JSON-stringified blobs.
+ */
+function formatObjectLiteral(data: Record<string, unknown>): string {
+  const parts: string[] = []
+  for (const [key, value] of Object.entries(data)) {
+    validateIdentifier(key)
+    parts.push(`${key}: ${quoteValue(value)}`)
+  }
+  return `{ ${parts.join(', ')} }`
+}
+
+/**
+ * Build the UPSERT target — either a record id (`user:alice`) or the bare
+ * table name. Validates the identifier when no colon is present so the bare
+ * table form can't be used to smuggle SurrealQL.
+ */
+function buildUpsertTarget(table: string, raw: string | undefined): string {
+  if (raw && raw.includes(':')) return raw
+  validateIdentifier(table)
+  return table
+}
+
+/**
+ * Batch upsert multiple records.
+ *
+ * Inserts records if they don't exist, or updates them if they do. Emits one
+ * `UPSERT <target> CONTENT { ... }` statement per record — matching the
+ * surql-py / surql-rs / surql-go ports — and batches them into a single
+ * multi-statement query in autocommit mode, or queues them on the supplied
+ * transaction in atomic mode.
+ *
+ * ## Atomicity (1.5.0)
+ *
+ * `client` may be either a connected `Surreal` connection or an active
+ * {@link Transaction}. The two modes behave differently:
+ *
+ * - **Surreal — autocommit.** The batch is sent as a single multi-statement
+ *   query. If one record fails schema validation mid-batch, *earlier records
+ *   may already have committed* (SurrealDB v3 autocommits per statement
+ *   unless wrapped in `BEGIN … COMMIT`). This is the legacy behaviour and is
+ *   preserved for backwards compatibility.
+ *
+ * - **Transaction — atomic.** The same per-record `UPSERT` statements are
+ *   queued on the supplied transaction via `trx.execute`. They inherit the
+ *   surrounding `BEGIN TRANSACTION` / `COMMIT TRANSACTION` framing, so a
+ *   single bad record rolls back the *entire* batch on commit (no
+ *   half-seeded tables). Results are not available at call time — `Transaction
+ *   .execute` buffers statements — so this mode returns `[]`. Callers who
+ *   need the per-row results should inspect the value returned by
+ *   {@link Transaction.commit}.
+ *
+ * Use the transaction-bound form when seeding multiple tables in one atomic
+ * step or when partial-success would leave the database in a shape downstream
+ * code can't recover from. The mode is auto-detected from `client` so no API
+ * call-site rewrite is needed beyond passing the transaction handle.
+ *
+ * @param client - `Surreal` connection (autocommit) or active `Transaction` (atomic)
+ * @param table - target table name
+ * @param items - records to upsert; an `id` field is used as the target if present
+ * @param conflictFields - optional fields appended as a `WHERE` clause for conflict detection
+ *
+ * @example Basic autocommit upsert (legacy behaviour):
+ * ```ts
+ * const results = await upsertMany(db, 'users', [
+ *   { id: 'user:1', name: 'Alice', age: 30 },
+ *   { id: 'user:2', name: 'Bob', age: 25 },
+ * ])
+ * ```
+ *
+ * @example Atomic batch — rolls back if any record fails validation:
+ * ```ts
+ * const trx = transaction(db)
+ * await trx.begin()
+ * try {
+ *   await upsertMany(trx, 'users', usersBatch)
+ *   await upsertMany(trx, 'posts', postsBatch)
+ *   await trx.commit() // commits both atomically; either failure rolls all back
+ * } catch (e) {
+ *   if (trx.isActive) await trx.cancel()
+ *   throw e
+ * }
+ * ```
  */
 export async function upsertMany<T = Record<string, unknown>>(
-  db: Surreal,
+  client: Surreal | Transaction,
   table: string,
   items: Record<string, unknown>[],
+  conflictFields?: string[],
 ): Promise<T[]> {
   if (items.length === 0) return []
-  const tableName = escapeTable(table)
+
+  validateIdentifier(table)
+  if (conflictFields) {
+    for (const f of conflictFields) validateIdentifier(f)
+  }
+
+  const txn = client instanceof Transaction ? client : undefined
 
   try {
-    const results: T[] = []
+    const statements: string[] = []
     for (const item of items) {
-      const entries = Object.entries(item)
-      const setClauses = entries.map(([k, v]) => `${k} = ${quoteValue(v)}`).join(', ')
-      const sql = `UPSERT ${tableName} SET ${setClauses}`
-      const res = await db.query<T[]>(sql) as unknown as T[][]
-      if (res[0]?.length) results.push(...res[0])
+      const id = typeof item.id === 'string' ? item.id : undefined
+      const target = buildUpsertTarget(table, id)
+      const payload: Record<string, unknown> = {}
+      for (const [k, v] of Object.entries(item)) {
+        if (k !== 'id') payload[k] = v
+      }
+      const literal = formatObjectLiteral(payload)
+      if (conflictFields && conflictFields.length > 0) {
+        const conditions = conflictFields
+          .map((f) => `${f} = ${quoteValue(payload[f])}`)
+          .join(' AND ')
+        statements.push(`UPSERT ${target} CONTENT ${literal} WHERE ${conditions}`)
+      } else {
+        statements.push(`UPSERT ${target} CONTENT ${literal}`)
+      }
     }
-    return results
+
+    if (txn !== undefined) {
+      // Queue each statement individually so a future per-statement
+      // bookkeeping addition to `Transaction.execute` (duplicate-key detection,
+      // statement-level retries) works correctly. The full batch then flushes
+      // as a single `BEGIN … COMMIT` RPC on `Transaction.commit`, inheriting
+      // v3's rollback-on-any-error semantics. Results aren't available until
+      // commit — return an empty list and let callers inspect the array
+      // returned by `Transaction.commit` if they need per-row data.
+      for (const stmt of statements) {
+        await txn.execute<T>(stmt)
+      }
+      return []
+    }
+
+    // `client` is narrowed to `Surreal` in this branch — the `txn` shortcut
+    // above peeled off the Transaction case.
+    const db = client as Surreal
+    const sql = statements.join(';\n') + ';'
+    const results = await db.query<T[]>(sql) as unknown as T[][]
+    // The query returns one result set per statement; concatenate the
+    // returned rows in order so a caller upserting N records gets back N rows
+    // (matching surql-py's autocommit behaviour).
+    const out: T[] = []
+    for (const set of results ?? []) {
+      if (Array.isArray(set)) out.push(...set)
+    }
+    return out
   } catch (e) {
+    // Let TransactionError propagate verbatim — it carries an actionable
+    // "transaction is in state X" diagnostic that gets swallowed by the
+    // generic "Batch upsert failed" wrapper.
+    if (e instanceof TransactionError) throw e
     throw intoSurQlError('Batch upsert failed:', e)
   }
 }
@@ -105,8 +239,13 @@ export async function relateMany<T = Record<string, unknown>>(
 }
 
 /**
- * Build a SurrealQL UPSERT query string without executing it.
- * Useful for previewing or logging the query before execution.
+ * Build a SurrealQL UPSERT query string without executing it. Useful for
+ * previewing or logging the query before execution.
+ *
+ * Emits one `UPSERT <target> CONTENT { ... }` statement per item, joined by
+ * `;`. SurrealDB v3 rejects the older `UPSERT INTO <table> [ {...}, {...} ]`
+ * shape with a parse error, so the per-record form is the only portable
+ * pattern across the surql-py / surql-rs / surql-go ports.
  */
 export function buildUpsertQuery(
   table: string,
@@ -120,17 +259,26 @@ export function buildUpsertQuery(
     for (const f of conflictFields) validateIdentifier(f)
   }
 
-  const itemsArray = items.map((item) => {
-    const entries = Object.entries(item)
-    return `{ ${entries.map(([k, v]) => `${k}: ${quoteValue(v)}`).join(', ')} }`
-  }).join(', ')
-
-  if (conflictFields && conflictFields.length > 0) {
-    const conditions = conflictFields.map((f) => `${f} = $item.${f}`).join(' AND ')
-    return `UPSERT INTO ${table} [${itemsArray}] WHERE ${conditions};`
+  const statements: string[] = []
+  for (const item of items) {
+    const id = typeof item.id === 'string' ? item.id : undefined
+    const target = buildUpsertTarget(table, id)
+    const payload: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(item)) {
+      if (k !== 'id') payload[k] = v
+    }
+    const literal = formatObjectLiteral(payload)
+    if (conflictFields && conflictFields.length > 0) {
+      const conditions = conflictFields
+        .map((f) => `${f} = ${quoteValue(payload[f])}`)
+        .join(' AND ')
+      statements.push(`UPSERT ${target} CONTENT ${literal} WHERE ${conditions};`)
+    } else {
+      statements.push(`UPSERT ${target} CONTENT ${literal};`)
+    }
   }
 
-  return `UPSERT INTO ${table} [${itemsArray}];`
+  return statements.join('\n')
 }
 
 /**

--- a/src/schema/parser.ts
+++ b/src/schema/parser.ts
@@ -121,7 +121,12 @@ const M_RE = /\bM\s+(\d+)/i
 const WHEN_RE = /WHEN\s+([\s\S]+?)\s+THEN/i
 const THEN_BRACE_RE = /THEN\s+\{([\s\S]+?)\}(?:\s*;|\s*$)/i
 const THEN_BARE_RE = /THEN\s+([\s\S]+?)(?:\s*;|\s*$)/i
-const RELATION_RE = /TYPE\s+RELATION\s+FROM\s+(\w+)\s+TO\s+(\w+)/i
+/** `TYPE RELATION` keyword anywhere in a `DEFINE TABLE` string. */
+const TYPE_RELATION_RE = /\bTYPE\s+RELATION\b/i
+/** `FROM <ident>` clause in a `DEFINE TABLE` string, independent of `TO`. */
+const EDGE_FROM_RE = /\bFROM\s+([A-Za-z_][A-Za-z0-9_]*)/i
+/** `TO <ident>` clause in a `DEFINE TABLE` string, independent of `FROM`. */
+const EDGE_TO_RE = /\bTO\s+([A-Za-z_][A-Za-z0-9_]*)/i
 const ALGORITHM_RE = /ALGORITHM\s+(\w+)/i
 const KEY_RE = /KEY\s+'([^']*)'/i
 const URL_RE = /URL\s+'([^']*)'/i
@@ -771,23 +776,70 @@ export function parseTableInfo(tableName: string, info: unknown, defineTable?: s
 }
 
 function isEdgeDefinition(source: string): boolean {
-  return RELATION_RE.test(source)
-}
-
-function extractRelationEndpoints(definition: string): { from: string; to: string } | undefined {
-  const m = RELATION_RE.exec(definition)
-  if (!m) return undefined
-  return { from: m[1], to: m[2] }
+  return TYPE_RELATION_RE.test(source)
 }
 
 /**
- * Parse a SurrealDB `INFO FOR TABLE` response that represents a relation edge
- * into an `EdgeDefinition`.
+ * Parse the edge mode encoded in a `DEFINE TABLE` statement string.
+ *
+ * Recognises the three shapes the emitter writes:
+ * - `TYPE RELATION ...` → {@link EdgeMode.RELATION}
+ * - `SCHEMAFULL` → {@link EdgeMode.SCHEMAFULL}
+ * - anything else (including empty / `SCHEMALESS`) → {@link EdgeMode.SCHEMALESS}
+ *
+ * `TYPE RELATION` wins over `SCHEMAFULL` / `SCHEMALESS` because SurrealDB v3
+ * allows `DEFINE TABLE <name> TYPE RELATION SCHEMAFULL ...` and the edge mode
+ * is what matters for downstream diffing.
+ */
+function parseEdgeMode(definition: string): EdgeMode {
+  if (!definition) return EdgeMode.SCHEMALESS
+  if (TYPE_RELATION_RE.test(definition)) return EdgeMode.RELATION
+  const upper = definition.toUpperCase()
+  if (upper.includes('SCHEMAFULL')) return EdgeMode.SCHEMAFULL
+  return EdgeMode.SCHEMALESS
+}
+
+/**
+ * Extract `FROM <table>` and `TO <table>` from a `DEFINE TABLE` string without
+ * requiring them to appear together. SurrealDB v3 emits `RELATION FROM x TO y`
+ * for typed edges, but the parser stays permissive on read: a malformed live
+ * definition that lost one clause surfaces as missing-endpoint drift instead
+ * of a parse failure.
+ */
+function extractEdgeEndpoints(definition: string): { from?: string; to?: string } {
+  if (!definition) return {}
+  const out: { from?: string; to?: string } = {}
+  const fromMatch = EDGE_FROM_RE.exec(definition)
+  if (fromMatch) out.from = fromMatch[1]
+  const toMatch = EDGE_TO_RE.exec(definition)
+  if (toMatch) out.to = toMatch[1]
+  return out
+}
+
+/**
+ * Parse a SurrealDB `INFO FOR TABLE` response that represents a graph edge
+ * into an `EdgeDefinition`. Counterpart to {@link parseTableInfo} for graph-edge
+ * tables defined via `edgeSchema` / {@link EdgeDefinition}.
+ *
+ * Edges round-trip through SurrealDB as regular tables in `INFO FOR DB.tables`;
+ * the only thing that makes them edges is the `TYPE RELATION FROM <x> TO <y>`
+ * clause on the `DEFINE TABLE` statement. Without an edge-aware parser, a
+ * drift detector using {@link parseTableInfo} against an edge table would see
+ * it as a SCHEMALESS table missing every field-level diff signal an edge
+ * expects (mode, from/to constraints, auto `in`/`out` proxies).
+ *
+ * For `RELATION`-mode edges the auto-emitted `in` and `out` fields SurrealDB
+ * stores are skipped — they are implicit when `TYPE RELATION` is set, so the
+ * code-side `EdgeDefinition` does not declare them either.
  *
  * As with {@link parseTableInfo}, pass `defineTable` — the
- * `DEFINE TABLE <name> TYPE RELATION ...` string from `INFO FOR DB` — so the
- * `FROM` / `TO` endpoints can be recovered on SurrealDB v3.
+ * `DEFINE TABLE <name> ...` string from `INFO FOR DB` — so the mode,
+ * `FROM`/`TO` endpoints, and `PERMISSIONS` can be recovered on SurrealDB v3
+ * (which omits the table-level `DEFINE` from `INFO FOR TABLE`).
  *
+ * @param edgeName - edge table name (attached to the returned definition)
+ * @param info - raw `INFO FOR TABLE` response object
+ * @param defineTable - optional `DEFINE TABLE` statement, sourced from `INFO FOR DB`
  * @throws {@link SchemaParseError} when `info` is not a plain object
  */
 export function parseEdgeInfo(edgeName: string, info: unknown, defineTable?: string): EdgeDefinition {
@@ -797,10 +849,19 @@ export function parseEdgeInfo(edgeName: string, info: unknown, defineTable?: str
   const obj = expectObject(info, `INFO FOR TABLE ${edgeName}`)
 
   const tb = defineTable !== undefined ? defineTable : stringAt(obj, 'tb')
-  const endpoints = extractRelationEndpoints(tb)
+  const mode = parseEdgeMode(tb)
+  const endpoints = extractEdgeEndpoints(tb)
 
   const fieldsValue = pickMap(obj, ['fields', 'fd'])
-  const fields = fieldsValue ? parseFields(valueToStringMap(fieldsValue)) : []
+  let fields = fieldsValue ? parseFields(valueToStringMap(fieldsValue)) : []
+  // SurrealDB auto-emits `in` and `out` fields for TYPE RELATION edges. They
+  // are implicit when `TYPE RELATION` is set, so the code-side EdgeDefinition
+  // does not declare them. Strip them on read so round-trip diffs do not flag
+  // them as orphan additions.
+  if (mode === EdgeMode.RELATION) {
+    fields = fields.filter((f) => f.name !== 'in' && f.name !== 'out')
+  }
+
   const indexesValue = pickMap(obj, ['indexes', 'ix'])
   const indexes = indexesValue ? parseIndexes(valueToStringMap(indexesValue)) : []
   const eventsValue = pickMap(obj, ['events', 'ev'])
@@ -808,15 +869,13 @@ export function parseEdgeInfo(edgeName: string, info: unknown, defineTable?: str
 
   const edge: Mutable<EdgeDefinition> = {
     name: edgeName,
-    mode: EdgeMode.RELATION,
+    mode,
     fields,
     indexes,
     events,
   }
-  if (endpoints) {
-    edge.fromTable = endpoints.from
-    edge.toTable = endpoints.to
-  }
+  if (endpoints.from !== undefined) edge.fromTable = endpoints.from
+  if (endpoints.to !== undefined) edge.toTable = endpoints.to
   const permissions = parseTablePermissions(tb)
   if (permissions !== undefined) edge.permissions = permissions
 
@@ -848,18 +907,16 @@ export function parseDbInfo(info: unknown): DatabaseInfo {
     for (const [name, rawDef] of Object.entries(tb)) {
       if (typeof rawDef !== 'string') continue
       if (isEdgeDefinition(rawDef)) {
-        const endpoints = extractRelationEndpoints(rawDef)
+        const endpoints = extractEdgeEndpoints(rawDef)
         const edge: Mutable<EdgeDefinition> = {
           name,
-          mode: EdgeMode.RELATION,
+          mode: parseEdgeMode(rawDef),
           fields: [],
           indexes: [],
           events: [],
         }
-        if (endpoints) {
-          edge.fromTable = endpoints.from
-          edge.toTable = endpoints.to
-        }
+        if (endpoints.from !== undefined) edge.fromTable = endpoints.from
+        if (endpoints.to !== undefined) edge.toTable = endpoints.to
         const edgePermissions = parseTablePermissions(rawDef)
         if (edgePermissions !== undefined) edge.permissions = edgePermissions
         edges[name] = Object.freeze(edge)

--- a/src/test/batch_async.test.ts
+++ b/src/test/batch_async.test.ts
@@ -63,11 +63,13 @@ describe('upsertMany', () => {
     assertEquals(result.length, 0)
   })
 
-  it('should execute one UPSERT per item', async () => {
-    const mockResp = [
-      [[{ id: 'users:1', name: 'Alice' }]],
-      [[{ id: 'users:2', name: 'Bob' }]],
-    ]
+  it('should batch into a single multi-statement query (one UPSERT per item)', async () => {
+    // Per-statement result envelopes returned by the SDK; concatenated into a
+    // single results array by upsertMany in autocommit mode.
+    const mockResp = [[
+      [{ id: 'users:1', name: 'Alice' }],
+      [{ id: 'users:2', name: 'Bob' }],
+    ]]
     // deno-lint-ignore no-explicit-any
     const db = makeMockDb(mockResp) as any
     const result = await upsertMany(db, 'users', [
@@ -75,9 +77,35 @@ describe('upsertMany', () => {
       { name: 'Bob' },
     ])
     assertEquals(result.length, 2)
-    assertEquals(db.queries.length, 2)
-    assertEquals(db.queries[0].includes('UPSERT users SET'), true)
-    assertEquals(db.queries[1].includes('UPSERT users SET'), true)
+    // One multi-statement query is emitted — autocommit mode batches the
+    // per-record UPSERTs together.
+    assertEquals(db.queries.length, 1)
+    assertEquals(db.queries[0].split('UPSERT users CONTENT').length - 1, 2)
+    assertEquals(db.queries[0].includes("name: 'Alice'"), true)
+    assertEquals(db.queries[0].includes("name: 'Bob'"), true)
+  })
+
+  it('should target a specific record id when `id` is present in the item', async () => {
+    const mockResp = [[[{ id: 'users:alice', name: 'Alice' }]]]
+    // deno-lint-ignore no-explicit-any
+    const db = makeMockDb(mockResp) as any
+    await upsertMany(db, 'users', [{ id: 'users:alice', name: 'Alice' }])
+    assertEquals(db.queries[0].includes('UPSERT users:alice CONTENT'), true)
+    // `id` is the target, not part of the payload.
+    assertEquals(db.queries[0].includes("id: 'users:alice'"), false)
+  })
+
+  it('should emit a WHERE clause from conflictFields with inline values', async () => {
+    const mockResp = [[[{ id: 'users:1', email: 'a@b.com' }]]]
+    // deno-lint-ignore no-explicit-any
+    const db = makeMockDb(mockResp) as any
+    await upsertMany(
+      db,
+      'users',
+      [{ email: 'a@b.com', name: 'Alice' }],
+      ['email'],
+    )
+    assertEquals(db.queries[0].includes("WHERE email = 'a@b.com'"), true)
   })
 
   it('should wrap db errors', async () => {

--- a/src/test/batch_query.test.ts
+++ b/src/test/batch_query.test.ts
@@ -7,30 +7,44 @@ describe('buildUpsertQuery', () => {
     assertEquals(buildUpsertQuery('users', []), '')
   })
 
-  it('should build a simple upsert query', () => {
+  it('should build a simple upsert query (per-record CONTENT, v3-safe)', () => {
     const result = buildUpsertQuery('users', [{ name: 'Alice', age: 30 }])
-    assertStringIncludes(result, 'UPSERT INTO users')
+    // v3 rejects `UPSERT INTO <table> [ ... ]`; the per-record CONTENT form is
+    // the only portable shape across surql-py / surql-rs / surql-go.
+    assertStringIncludes(result, 'UPSERT users CONTENT')
     assertStringIncludes(result, "name: 'Alice'")
     assertStringIncludes(result, 'age: 30')
     assertEquals(result.endsWith(';'), true)
   })
 
-  it('should build upsert for multiple items', () => {
+  it('should emit one UPSERT statement per item', () => {
     const result = buildUpsertQuery('users', [
       { name: 'Alice', age: 30 },
       { name: 'Bob', age: 25 },
     ])
+    // Two records → two UPSERT statements.
+    assertEquals(result.split('UPSERT users CONTENT').length - 1, 2)
     assertStringIncludes(result, "name: 'Alice'")
     assertStringIncludes(result, "name: 'Bob'")
   })
 
-  it('should include conflict fields in WHERE clause', () => {
+  it('should target a specific record id when `id` is present in the item', () => {
+    const result = buildUpsertQuery('users', [{ id: 'user:alice', name: 'Alice' }])
+    // The `id` field becomes the UPSERT target (not part of the CONTENT payload).
+    assertStringIncludes(result, 'UPSERT user:alice CONTENT')
+    assertEquals(result.includes("id: 'user:alice'"), false)
+  })
+
+  it('should include conflict fields in WHERE clause with inline values', () => {
     const result = buildUpsertQuery(
       'users',
       [{ email: 'a@b.com', name: 'Alice' }],
       ['email'],
     )
-    assertStringIncludes(result, 'WHERE email = $item.email')
+    // The query is a single self-contained statement (no $item.* param refs)
+    // so it can be embedded inside a buffered transaction whose execute() does
+    // not bind params.
+    assertStringIncludes(result, "WHERE email = 'a@b.com'")
   })
 
   it('should combine multiple conflict fields with AND', () => {
@@ -39,7 +53,7 @@ describe('buildUpsertQuery', () => {
       [{ email: 'a@b.com', name: 'Alice' }],
       ['email', 'name'],
     )
-    assertStringIncludes(result, 'email = $item.email AND name = $item.name')
+    assertStringIncludes(result, "email = 'a@b.com' AND name = 'Alice'")
   })
 
   it('should reject invalid table names', () => {

--- a/src/test/batch_transaction.test.ts
+++ b/src/test/batch_transaction.test.ts
@@ -1,0 +1,197 @@
+import { assertEquals, assertRejects, assertStringIncludes } from '@std/assert'
+import { describe, it } from '@std/testing/bdd'
+import { transaction, TransactionState } from '../connection/transaction.ts'
+import { TransactionError } from '../connection/errors.ts'
+import { upsertMany } from '../query/batch.ts'
+
+// Regression tests for the v1.5.0 transaction-bound upsertMany. The `client`
+// argument now accepts either a `Surreal` connection (autocommit, legacy
+// behaviour) or an active `Transaction` (atomic — the per-record UPSERT
+// statements are queued on the transaction buffer and inherit the surrounding
+// BEGIN/COMMIT framing on commit).
+
+interface MockedSurreal {
+  queries: { sql: string; params?: Record<string, unknown> }[]
+  responses: unknown[][][]
+  // deno-lint-ignore no-explicit-any
+  query: (...args: any[]) => any
+}
+
+/** Build a minimal mock that captures every query() call. */
+function makeMockDb(responses: unknown[][][]): MockedSurreal {
+  const queries: { sql: string; params?: Record<string, unknown> }[] = []
+  let callIndex = 0
+  return {
+    queries,
+    responses,
+    query(sql: string, params?: Record<string, unknown>) {
+      queries.push({ sql, params })
+      const resp = responses[callIndex] ?? [[]]
+      callIndex++
+      // The Surreal SDK's query() can be awaited directly OR have .responses()
+      // called on it for per-statement envelopes. Return a thenable shaped
+      // like a Promise but with .responses() bolted on; the buffered
+      // Transaction.commit() path uses .responses().
+      const promise = Promise.resolve(resp)
+      // Synthesise BEGIN/COMMIT envelopes around the user statements.
+      const envelope = [
+        { success: true, result: null },
+        ...((resp[0] as unknown[]) ?? []).map((r) => ({ success: true, result: r })),
+        { success: true, result: null },
+      ]
+      const withResponses = promise as unknown as Promise<unknown[][]> & {
+        responses: () => Promise<unknown[]>
+      }
+      withResponses.responses = () => Promise.resolve(envelope)
+      return promise
+    },
+  }
+}
+
+describe('upsertMany (autocommit)', () => {
+  it('emits one multi-statement query in autocommit mode', async () => {
+    const mockResp = [[
+      [{ id: 'users:1', name: 'Alice' }],
+      [{ id: 'users:2', name: 'Bob' }],
+    ]]
+    // deno-lint-ignore no-explicit-any
+    const db = makeMockDb(mockResp) as any
+    const result = await upsertMany<{ id: string; name: string }>(db, 'users', [
+      { name: 'Alice' },
+      { name: 'Bob' },
+    ])
+    assertEquals(result.length, 2)
+    assertEquals(db.queries.length, 1)
+    // The batched query contains two UPSERT statements joined by `;`.
+    const sql = db.queries[0].sql as string
+    assertEquals(sql.split('UPSERT users CONTENT').length - 1, 2)
+  })
+
+  it('uses the `id` field as the per-record UPSERT target', async () => {
+    const mockResp = [[[{ id: 'users:alice', name: 'Alice' }]]]
+    // deno-lint-ignore no-explicit-any
+    const db = makeMockDb(mockResp) as any
+    await upsertMany(db, 'users', [{ id: 'users:alice', name: 'Alice' }])
+    assertStringIncludes(db.queries[0].sql as string, 'UPSERT users:alice CONTENT')
+  })
+
+  it('returns [] for empty input without contacting the db', async () => {
+    // deno-lint-ignore no-explicit-any
+    const db = makeMockDb([]) as any
+    const result = await upsertMany(db, 'users', [])
+    assertEquals(result.length, 0)
+    assertEquals(db.queries.length, 0)
+  })
+
+  it('rejects an invalid table identifier', async () => {
+    // deno-lint-ignore no-explicit-any
+    const db = makeMockDb([]) as any
+    await assertRejects(
+      () => upsertMany(db, 'bad table', [{ x: 1 }]),
+      Error,
+      'Invalid identifier',
+    )
+  })
+
+  it('rejects an invalid conflict field identifier', async () => {
+    // deno-lint-ignore no-explicit-any
+    const db = makeMockDb([]) as any
+    await assertRejects(
+      () => upsertMany(db, 'users', [{ x: 1 }], ['bad field']),
+      Error,
+      'Invalid identifier',
+    )
+  })
+})
+
+describe('upsertMany (transaction-bound)', () => {
+  it('queues per-record UPSERTs on the transaction and returns []', async () => {
+    // deno-lint-ignore no-explicit-any
+    const db = makeMockDb([]) as any
+    const trx = transaction(db)
+    await trx.begin()
+    const result = await upsertMany(trx, 'users', [
+      { name: 'Alice' },
+      { name: 'Bob' },
+    ])
+    // Atomic mode buffers — results land in commit() instead.
+    assertEquals(result.length, 0)
+    // Nothing has hit the network yet — Transaction.execute() just buffers.
+    assertEquals(db.queries.length, 0)
+    // The two UPSERTs are now queued. Cancel without committing so we don't
+    // assert on the BEGIN/COMMIT round-trip here.
+    await trx.cancel()
+    assertEquals(trx.state, TransactionState.CANCELLED)
+  })
+
+  it('preserves the v3-correct per-record UPSERT shape inside the transaction', async () => {
+    // Commit the transaction so we can inspect the bundled BEGIN ... COMMIT
+    // payload that was actually sent to the server.
+    const mockResp = [[
+      [{ id: 'users:alice', name: 'Alice' }],
+      [{ id: 'users:bob', name: 'Bob' }],
+    ]]
+    // deno-lint-ignore no-explicit-any
+    const db = makeMockDb(mockResp) as any
+    const trx = transaction(db)
+    await trx.begin()
+    await upsertMany(trx, 'users', [
+      { id: 'users:alice', name: 'Alice' },
+      { id: 'users:bob', name: 'Bob' },
+    ])
+    const results = await trx.commit()
+    assertEquals(trx.state, TransactionState.COMMITTED)
+    // Two user statements committed → two result entries (BEGIN/COMMIT
+    // bookends are stripped by Transaction.commit).
+    assertEquals(results.length, 2)
+    // The single RPC contains BEGIN, both targeted UPSERTs, and COMMIT.
+    assertEquals(db.queries.length, 1)
+    const sql = db.queries[0].sql as string
+    assertStringIncludes(sql, 'BEGIN TRANSACTION')
+    assertStringIncludes(sql, 'UPSERT users:alice CONTENT')
+    assertStringIncludes(sql, 'UPSERT users:bob CONTENT')
+    assertStringIncludes(sql, 'COMMIT TRANSACTION')
+  })
+
+  it('rejects when the supplied transaction is not active', async () => {
+    // deno-lint-ignore no-explicit-any
+    const db = makeMockDb([]) as any
+    const trx = transaction(db)
+    // No begin() — still PENDING.
+    await assertRejects(
+      () => upsertMany(trx, 'users', [{ name: 'X' }]),
+      TransactionError,
+      'Cannot execute in transaction state',
+    )
+  })
+
+  it('inlines conflictFields values into a WHERE clause (Transaction.execute does not bind params)', async () => {
+    // surql's buffered transactions queue raw SQL strings — the `params` arg
+    // on Transaction.execute is intentionally unused — so conflictFields must
+    // inline their values. surql-py's bound-param shape (`$item.field`) would
+    // never resolve in this code path.
+    // deno-lint-ignore no-explicit-any
+    const db = makeMockDb([[[{ id: 'users:1' }]]]) as any
+    const trx = transaction(db)
+    await trx.begin()
+    await upsertMany(
+      trx,
+      'users',
+      [{ email: 'a@b.com', name: 'Alice' }],
+      ['email'],
+    )
+    await trx.commit()
+    const sql = db.queries[0].sql as string
+    assertStringIncludes(sql, "WHERE email = 'a@b.com'")
+  })
+
+  it('returns [] for empty input even when given a transaction', async () => {
+    // deno-lint-ignore no-explicit-any
+    const db = makeMockDb([]) as any
+    const trx = transaction(db)
+    await trx.begin()
+    const result = await upsertMany(trx, 'users', [])
+    assertEquals(result.length, 0)
+    await trx.cancel()
+  })
+})

--- a/src/test/parity.test.ts
+++ b/src/test/parity.test.ts
@@ -140,17 +140,17 @@ describe('Python Parity - New Items', () => {
   })
 
   describe('Query - Build Helpers', () => {
-    it('should build upsert query', () => {
+    it('should build upsert query (per-record CONTENT, v3-safe)', () => {
       const sql = buildUpsertQuery('users', [{ name: 'Alice' }, { name: 'Bob' }])
-      assertStringIncludes(sql, 'UPSERT INTO users')
+      assertStringIncludes(sql, 'UPSERT users CONTENT')
       assertStringIncludes(sql, 'Alice')
       assertStringIncludes(sql, 'Bob')
     })
 
-    it('should build upsert query with conflict fields', () => {
+    it('should build upsert query with conflict fields inlined', () => {
       const sql = buildUpsertQuery('users', [{ email: 'a@b.com' }], ['email'])
       assertStringIncludes(sql, 'WHERE')
-      assertStringIncludes(sql, 'email = $item.email')
+      assertStringIncludes(sql, "email = 'a@b.com'")
     })
 
     it('should return empty string for empty items', () => {

--- a/src/test/schema_parser.test.ts
+++ b/src/test/schema_parser.test.ts
@@ -501,6 +501,12 @@ describe('parseEdgeInfo', () => {
     assertThrows(() => parseEdgeInfo('', {}), SchemaParseError)
   })
 
+  it('rejects non-object info', () => {
+    assertThrows(() => parseEdgeInfo('likes', null), SchemaParseError)
+    assertThrows(() => parseEdgeInfo('likes', 'not an object'), SchemaParseError)
+    assertThrows(() => parseEdgeInfo('likes', [1, 2, 3]), SchemaParseError)
+  })
+
   it('extracts from/to + fields from relation', () => {
     const info = {
       tb: 'DEFINE TABLE likes TYPE RELATION FROM user TO product',
@@ -512,6 +518,164 @@ describe('parseEdgeInfo', () => {
     assertEquals(e.toTable, 'product')
     assertEquals(e.fields.length, 1)
     assertEquals(e.fields[0].name, 'weight')
+  })
+
+  it('uses defineTable override when supplied (v3 INFO FOR TABLE omits the table-level DEFINE)', () => {
+    // v3's INFO FOR TABLE does not include the table-level DEFINE — the
+    // DEFINE TABLE string only appears in INFO FOR DB.tables.<name>. A drift
+    // detector must pass that string explicitly so mode + FROM/TO + PERMISSIONS
+    // round-trip; without it the edge defaults to SCHEMALESS with no endpoints.
+    const e = parseEdgeInfo('likes', { fields: {} }, 'DEFINE TABLE likes TYPE RELATION FROM user TO product')
+    assertEquals(e.mode, EdgeMode.RELATION)
+    assertEquals(e.fromTable, 'user')
+    assertEquals(e.toTable, 'product')
+  })
+
+  it('detects SCHEMAFULL edge mode', () => {
+    const e = parseEdgeInfo('likes', { fields: {} }, 'DEFINE TABLE likes SCHEMAFULL')
+    assertEquals(e.mode, EdgeMode.SCHEMAFULL)
+    assertEquals(e.fromTable, undefined)
+    assertEquals(e.toTable, undefined)
+  })
+
+  it('detects SCHEMALESS edge mode when DEFINE TABLE has no mode keyword', () => {
+    const e = parseEdgeInfo('likes', { fields: {} }, 'DEFINE TABLE likes')
+    assertEquals(e.mode, EdgeMode.SCHEMALESS)
+  })
+
+  it('defaults to SCHEMALESS when no DEFINE TABLE is available', () => {
+    const e = parseEdgeInfo('likes', { fields: {} })
+    assertEquals(e.mode, EdgeMode.SCHEMALESS)
+  })
+
+  it('lets `TYPE RELATION` win when the edge is also marked SCHEMAFULL', () => {
+    // SurrealDB v3 accepts `DEFINE TABLE <e> TYPE RELATION SCHEMAFULL FROM x TO y`
+    // — the edge mode is RELATION regardless of the schema flag.
+    const e = parseEdgeInfo(
+      'likes',
+      { fields: {} },
+      'DEFINE TABLE likes TYPE RELATION SCHEMAFULL FROM user TO product',
+    )
+    assertEquals(e.mode, EdgeMode.RELATION)
+    assertEquals(e.fromTable, 'user')
+    assertEquals(e.toTable, 'product')
+  })
+
+  it('strips auto-emitted `in` and `out` fields on RELATION edges', () => {
+    // SurrealDB auto-emits `in` and `out` on a TYPE RELATION edge; the
+    // code-side EdgeDefinition doesn't declare them, so round-trip diffs
+    // would flag them as orphan additions if the parser kept them.
+    const info = {
+      tb: 'DEFINE TABLE likes TYPE RELATION FROM user TO product',
+      fields: {
+        in: 'DEFINE FIELD in ON likes TYPE record<user>',
+        out: 'DEFINE FIELD out ON likes TYPE record<product>',
+        weight: 'DEFINE FIELD weight ON likes TYPE float',
+      },
+    }
+    const e = parseEdgeInfo('likes', info)
+    assertEquals(e.mode, EdgeMode.RELATION)
+    assertEquals(e.fields.map((f) => f.name), ['weight'])
+  })
+
+  it('keeps `in` and `out` fields on non-RELATION edges (no auto-emission)', () => {
+    // On a non-RELATION edge there's no auto-emission; if a consumer
+    // explicitly declares `in` / `out` fields they should still round-trip.
+    const info = {
+      tb: 'DEFINE TABLE custom SCHEMAFULL',
+      fields: {
+        in: 'DEFINE FIELD in ON custom TYPE record<a>',
+        out: 'DEFINE FIELD out ON custom TYPE record<b>',
+      },
+    }
+    const e = parseEdgeInfo('custom', info)
+    assertEquals(e.mode, EdgeMode.SCHEMAFULL)
+    assertEquals(e.fields.map((f) => f.name).sort(), ['in', 'out'])
+  })
+
+  it('parses per-action PERMISSIONS from the table-level DEFINE', () => {
+    const define = 'DEFINE TABLE likes TYPE RELATION FROM user TO product ' +
+      'PERMISSIONS FOR select WHERE $auth.id != NONE FOR create WHERE $auth.id = in'
+    const e = parseEdgeInfo('likes', { fields: {} }, define)
+    assertEquals(e.permissions?.select, '$auth.id != NONE')
+    assertEquals(e.permissions?.create, '$auth.id = in')
+  })
+
+  it('parses the comma-joined PERMISSIONS shape v3 emits when actions share a rule', () => {
+    // v3 collapses `FOR select WHERE r FOR create WHERE r ...` to
+    // `FOR select, create, update, delete WHERE r`. The parser must explode
+    // that into the same per-action dict shape, otherwise every consumer with
+    // collapsed rules sees a false-positive MODIFY_PERMISSIONS drift.
+    const define = 'DEFINE TABLE likes TYPE RELATION FROM user TO product ' +
+      'PERMISSIONS FOR select, create, update, delete WHERE tenant = $auth.tenant'
+    const e = parseEdgeInfo('likes', { fields: {} }, define)
+    assertEquals(e.permissions?.select, 'tenant = $auth.tenant')
+    assertEquals(e.permissions?.create, 'tenant = $auth.tenant')
+    assertEquals(e.permissions?.update, 'tenant = $auth.tenant')
+    assertEquals(e.permissions?.delete, 'tenant = $auth.tenant')
+  })
+
+  it('parses indexes and events on edges', () => {
+    const info = {
+      tb: 'DEFINE TABLE likes TYPE RELATION FROM user TO product',
+      fields: {},
+      indexes: {
+        unique_pair: 'DEFINE INDEX unique_pair ON likes COLUMNS in, out UNIQUE',
+      },
+      events: {
+        notify_create: 'DEFINE EVENT notify_create ON likes WHEN $event = "CREATE" THEN { /* ... */ }',
+      },
+    }
+    const e = parseEdgeInfo('likes', info)
+    assertEquals(e.indexes.length, 1)
+    assertEquals(e.indexes[0].fields, ['in', 'out'])
+    assertEquals(e.indexes[0].type, IndexType.UNIQUE)
+    assertEquals(e.events.length, 1)
+    assertEquals(e.events[0].name, 'notify_create')
+  })
+
+  it('round-trips a nullable record-typed declared field on a SCHEMAFULL edge', () => {
+    // Non-RELATION edges can declare arbitrary fields. Make sure record<X> +
+    // option<record<X>> survive the parser.
+    const info = {
+      tb: 'DEFINE TABLE custom SCHEMAFULL',
+      fields: {
+        target: 'DEFINE FIELD target ON custom TYPE record<thing>',
+        owner: 'DEFINE FIELD owner ON custom TYPE option<record<user>>',
+      },
+    }
+    const e = parseEdgeInfo('custom', info)
+    const target = e.fields.find((f) => f.name === 'target')!
+    assertEquals(target.type, FieldType.RECORD)
+    assertEquals(target.recordLink, 'thing')
+    const owner = e.fields.find((f) => f.name === 'owner')!
+    assertEquals(owner.type, FieldType.RECORD)
+    assertEquals(owner.recordLink, 'user')
+    assertEquals(owner.optional, true)
+  })
+
+  it('handles a field whose name collides with a clause keyword (e.g. `default`)', () => {
+    // Regression: the field-name-vs-clause-keyword split must work on edges
+    // too — splitFieldClauses skips the `DEFINE FIELD <name> ON …` prefix
+    // before scanning for clause-keyword anchors.
+    const info = {
+      tb: 'DEFINE TABLE custom SCHEMAFULL',
+      fields: { default: 'DEFINE FIELD default ON custom TYPE bool DEFAULT false' },
+    }
+    const e = parseEdgeInfo('custom', info)
+    assertEquals(e.fields.length, 1)
+    assertEquals(e.fields[0].name, 'default')
+    assertEquals(e.fields[0].type, FieldType.BOOL)
+    assertEquals(e.fields[0].defaultValue, 'false')
+  })
+
+  it('returns endpoints as undefined when DEFINE TABLE lacks FROM/TO', () => {
+    // Permissive on read: a malformed live definition surfaces as missing
+    // endpoints, not a parse failure.
+    const e = parseEdgeInfo('likes', { fields: {} }, 'DEFINE TABLE likes TYPE RELATION')
+    assertEquals(e.mode, EdgeMode.RELATION)
+    assertEquals(e.fromTable, undefined)
+    assertEquals(e.toTable, undefined)
   })
 })
 

--- a/src/test/strip_brackets.test.ts
+++ b/src/test/strip_brackets.test.ts
@@ -1,0 +1,84 @@
+import { assertEquals } from '@std/assert'
+import { describe, it } from '@std/testing/bdd'
+import { recordIdToString, stripBrackets } from '../utils/helpers.ts'
+import { RecordId } from 'surrealdb'
+
+// Regression tests for the v1.5.0 wire-format bracket helper. SurrealDB v3
+// wraps record-id keys that contain anything other than `[a-zA-Z_][a-zA-Z0-9_]*`
+// or pure digits in unicode angle brackets `⟨ … ⟩` (U+27E8 / U+27E9). Consumers
+// that want the bare `table:id` shape were previously calling `replace('⟨', '')
+// .replace('⟩', '')` themselves at every API boundary; `stripBrackets`
+// centralises that strip and also accepts the legacy ASCII `<…>` form.
+
+describe('stripBrackets', () => {
+  it('strips unicode brackets from a v3 wire-format record-id string', () => {
+    assertEquals(stripBrackets('outlet:⟨alaska.com⟩'), 'outlet:alaska.com')
+  })
+
+  it('strips a hyphenated id (the common case)', () => {
+    assertEquals(
+      stripBrackets('plan_chunk:⟨demo-plan-ff3d5981⟩'),
+      'plan_chunk:demo-plan-ff3d5981',
+    )
+  })
+
+  it('passes a bare identifier through untouched', () => {
+    assertEquals(stripBrackets('user:alice'), 'user:alice')
+  })
+
+  it('strips legacy ASCII brackets too (older serialisers)', () => {
+    assertEquals(stripBrackets('outlet:<legacy.com>'), 'outlet:legacy.com')
+  })
+
+  it('returns null untouched', () => {
+    assertEquals(stripBrackets(null), null)
+  })
+
+  it('returns undefined untouched', () => {
+    assertEquals(stripBrackets(undefined), undefined)
+  })
+
+  it('handles an empty string', () => {
+    assertEquals(stripBrackets(''), '')
+  })
+
+  it('strips both forms in a single string', () => {
+    // Pathological mixed input — both shapes appear. The helper just nukes
+    // any bracket character; it does not validate the structure.
+    assertEquals(stripBrackets('a:⟨x⟩;b:<y>'), 'a:x;b:y')
+  })
+
+  it('strips brackets from a composite (colon-containing) id', () => {
+    // SurrealDB v3 lets the id portion itself contain colons inside brackets.
+    // Stripping should expose the composite shape; how the caller splits it
+    // is downstream.
+    assertEquals(
+      stripBrackets('community:⟨BFS:lakewood⟩'),
+      'community:BFS:lakewood',
+    )
+  })
+})
+
+describe('recordIdToString', () => {
+  it('returns a string input as-is', () => {
+    assertEquals(recordIdToString('user:alice'), 'user:alice')
+  })
+
+  it('strips unicode brackets when converting a RecordId with a hyphenated id', () => {
+    const rid = new RecordId('community', 'lakewood-village')
+    // The SDK auto-wraps the special-char id in unicode brackets on toString;
+    // recordIdToString strips them so the bare wire shape is the consumer's
+    // default representation.
+    assertEquals(recordIdToString(rid), 'community:lakewood-village')
+  })
+
+  it('preserves a plain identifier id unchanged', () => {
+    const rid = new RecordId('user', 'alice')
+    assertEquals(recordIdToString(rid), 'user:alice')
+  })
+
+  it('renders numeric ids unbracketed', () => {
+    const rid = new RecordId('post', 42)
+    assertEquals(recordIdToString(rid), 'post:42')
+  })
+})

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -102,17 +102,46 @@ export function sanitizeErrorMessage(message: string, includeDetails: boolean): 
 }
 
 /**
- * Convert a SurrealDB RecordId to a string
+ * Strip SurrealDB v3 wire-format angle brackets from a record-id-shaped string.
  *
- * @param recordId - The RecordId to convert
- * @returns - The string representation of the RecordId
+ * SurrealDB v3 wraps record-id keys that contain special characters in unicode
+ * angle brackets — `'outlet:⟨alaskabeacon.com⟩'`, `'plan_chunk:⟨demo-plan-ff3d5981⟩'`.
+ * Downstream callers that want the bare `table:id` shape (API responses, log
+ * lines, string-keyed lookups) previously had to call
+ * `value.replace('⟨', '').replace('⟩', '')` themselves at every boundary. This
+ * helper centralises that strip.
+ *
+ * Both forms are accepted on input: the v3 unicode brackets (`⟨…⟩`, U+27E8 /
+ * U+27E9) and the legacy ASCII brackets (`<…>`). `null` and `undefined` are
+ * passed through untouched so the helper is safe to apply unconditionally.
+ *
+ * @example
+ * stripBrackets('outlet:⟨alaska.com⟩')        // 'outlet:alaska.com'
+ * stripBrackets('plan_chunk:⟨demo-plan-ff3d5981⟩')  // 'plan_chunk:demo-plan-ff3d5981'
+ * stripBrackets('user:alice')                  // 'user:alice'   (untouched)
+ * stripBrackets('outlet:<legacy.com>')         // 'outlet:legacy.com'  (ASCII form)
+ * stripBrackets(null)                          // null
+ */
+export function stripBrackets<T extends string | null | undefined>(value: T): T {
+  if (value === null || value === undefined) return value
+  // Unicode brackets first (the v3 norm), then ASCII as a fallback. Both forms
+  // are stripped because some clients still emit the legacy ASCII shape.
+  return value.replace(/[⟨⟩<>]/g, '') as T
+}
+
+/**
+ * Convert a SurrealDB RecordId to a bare `table:id` string.
+ *
+ * Strings are returned as-is; RecordId instances are stringified through the
+ * SDK's `toString()` and then run through {@link stripBrackets} so the result
+ * is the bare wire form without v3's escape brackets.
+ *
+ * @param recordId - The RecordId or string to convert
+ * @returns The string representation with brackets stripped
  */
 export function recordIdToString(recordId: RecordId | string): string {
   if (typeof recordId === 'string') return recordId
-
-  const result = recordId.toString()
-  // Strip angle brackets ⟨⟩ from SurrealDB RecordId format for backward compatibility
-  return result.replace(/⟨(.+?)⟩/g, '$1')
+  return stripBrackets(recordId.toString())
 }
 
 /**

--- a/src/utils/mod.ts
+++ b/src/utils/mod.ts
@@ -1,7 +1,14 @@
 /**
  * SurQL module exports
  */
-export { createSerializer, normalizeSurrealRecord, recordIdToString, type Serialized } from './helpers.ts'
+export {
+  createSerializer,
+  normalizeSurrealRecord,
+  normalizeSurrealRecords,
+  recordIdToString,
+  type Serialized,
+  stripBrackets,
+} from './helpers.ts'
 
 export { intoSurQlError, SurQlError, type SurQlErrorJson } from './surrealError.ts'
 


### PR DESCRIPTION
Brings surql to feature parity with the surql-py port's 1.6.4 → 1.7.0
release window.

## Added

- **Edge round-trip parity in the schema parser** (`parseEdgeInfo`):
  edge mode is detected from the `DEFINE TABLE` statement — `TYPE RELATION`
  resolves to `EdgeMode.RELATION`, `SCHEMAFULL` to `EdgeMode.SCHEMAFULL`,
  anything else to `EdgeMode.SCHEMALESS` (was hardcoded to `RELATION`).
  `FROM <table>` and `TO <table>` are parsed independently so a malformed
  live definition surfaces as missing-endpoint drift instead of a parse
  failure. On `TYPE RELATION` edges the auto-emitted `in`/`out` fields
  SurrealDB stores are stripped on parse — they are implicit when
  `TYPE RELATION` is set, so the code-side `EdgeDefinition` does not
  declare them and round-trip diffs were flagging them as orphan
  additions. Per-action `PERMISSIONS` round-trip via `parseTablePermissions`.

- **`stripBrackets(value)` helper** in `src/utils/helpers.ts`, also
  re-exported from the package root. Centralises the `.replace('⟨', '')
  .replace('⟩', '')` strip consumers were doing at every API boundary;
  also handles the legacy ASCII `<…>` form. `null`/`undefined` pass
  through untouched. `recordIdToString` now delegates to it.

- **Transaction-bound `upsertMany`**: the `client` argument now accepts
  either a `Surreal` connection (autocommit, legacy) or an active
  `Transaction` (atomic). In transaction mode the per-record UPSERT
  statements are queued on the supplied transaction via `trx.execute`,
  inheriting the surrounding `BEGIN`/`COMMIT` framing so a single bad
  record rolls the entire batch back on commit. Also gains an optional
  `conflictFields` parameter (matching surql-py) emitting an inline-value
  `WHERE` clause appended to each UPSERT.

## Fixed

- **`buildUpsertQuery` emitted `UPSERT INTO <table> [ {…}, {…} ]`** which
  SurrealDB v3 rejects with a parse error. Now emits one
  `UPSERT <target> CONTENT { … }` statement per item — the v3-correct
  shape used across the surql-py / -rs / -go ports — joined by `;`.

- **`upsertMany` ran one RPC per record.** Autocommit mode now batches
  all per-record UPSERTs into a single multi-statement query.

- **`upsertMany` did not honour the `id` field as the UPSERT target.**
  `{id: 'users:alice', name: 'Alice'}` now upserts the specific record
  (target = `users:alice`); the id is stripped from the CONTENT payload.

## Verified

- `deno fmt --check src/` — clean
- `deno lint src/` — clean
- `deno check src/cli/main.ts src/cli/mod.ts mod.ts` — clean
- `deno task test --ignore='src/test/integration*.test.ts'` — **199
  passed (1752 steps), 0 failed** (was 195/1712 on 1.4.0; +40 regression
  steps across schema_parser, strip_brackets, batch_transaction,
  batch_async, batch_query, parity).

## Housekeeping

- Version bumped to `1.5.0` in `deno.json`.