### PR TITLE
feat: full-text BM25 search (1:1 with surql-rs 0.29.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [1.6.0] - 2026-06-17
+
+### Added
+
+- **Full-text search (BM25) is now first-class — the sparse leg of hybrid retrieval.** Define a `DEFINE ANALYZER` in code with `analyzer(name)` / `standardAnalyzer(name)` (`AnalyzerDefinition` + `Tokenizer` + `TokenFilter`, composed with `withTokenizer` / `withFilters` and the `edgeNgram` / `ngram` / `snowball` filter factories, rendered via `analyzerToSurql` / `generateAnalyzerSql`); build a BM25-scored full-text index with `bm25Index(name, fields, analyzer)` (or `searchIndex(name, fields, analyzer, { bm25, highlights })`); and run the lexical query with `Query.fulltextSearch(field, reference, query)` + `Query.searchScore(reference, alias)`, or the `fulltextSearchQuery(...)` helper. `generateSchemaSql` accepts an `analyzers` array and emits `DEFINE ANALYZER` statements ahead of the tables that reference them. Pair it with `vectorSearch` and fuse the two result orders by rank (Reciprocal Rank Fusion). See `docs/v3-patterns.md`.
+
+### Fixed
+
+- **Full-text index now emits the SurrealDB 3.x `FULLTEXT` keyword.** The full-text index keyword was renamed from `SEARCH` to `FULLTEXT` in SurrealDB 3.0, so the previous output (`... SEARCH ANALYZER ascii`) was a parse error on v3. `IndexType.SEARCH` / `searchIndex` / `generateTableSql` / `generateEdgeSql` and the migration differ (`buildIndexSql`) now emit `FULLTEXT ANALYZER <analyzer|ascii> [BM25] [HIGHLIGHTS]`, and the `INFO FOR TABLE` index parser recognises both spellings (normalising the historical `ascii` analyzer back to undefined so default-form indexes round-trip). See `docs/v3-patterns.md` §"Full-text index renamed `SEARCH` → `FULLTEXT`" — including the note that the v3 streaming executor's full-text scan returns rows in BM25 relevance order but `search::score` is not plumbed through it (returns 0), so rank by the scan's natural order for RRF.
+
+### Verified
+
+- `deno fmt --check` — clean (on the canonical LF checkout / CI).
+- `deno lint` — clean (169 files).
+- `deno check mod.ts` / `deno check src/cli/main.ts src/cli/mod.ts` — clean.
+- `deno task test --ignore='src/test/integration*.test.ts'` — **206 passed (1782 steps)**, +8 tests / +32 steps over the 1.5.0 baseline of 198 passed (1750 steps), covering the analyzer builder, FULLTEXT/BM25 index rendering, the full-text query builder + single-quote escaping, and the parser round-trip. The one failing test (`CLI: db ping / schema tables` against a live database) is a pre-existing, environment-dependent failure unrelated to this change.
+
+### Housekeeping
+
+- Version bumped to `1.6.0` in `deno.json` (the npm package version is sourced from `deno.json` at `deno task build:npm` time, so the two stay in sync).
+
+---
+
 ## [1.5.0] - 2026-05-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Code-first database toolkit for [SurrealDB](https://surrealdb.com/). Type-safe q
 
 - **Fluent Query Builder** — Chainable API for SELECT/INSERT/UPDATE/DELETE with full generics; `typeRecord`, `timeNow`, `mathSum`, `countIf`, `stringLower` and friends render inline in both expression and `SET` contexts.
 - **Code-first Schema + Migrations** — `DEFINE` emitters with `IF NOT EXISTS`, structured schema parser, migration runner, squash, rollback, and drift detection.
-- **SurrealDB v3 correctness** — Buffered `BEGIN ... COMMIT`, unrolled `GraphQuery` depth, v3-valid `type::record()` everywhere.
+- **Hybrid search** — MTREE/HNSW vector indexes plus full-text **BM25** (`analyzer`, `bm25Index`, `fulltextSearch`/`searchScore`) for the sparse + dense legs of retrieval; fuse the two by rank (RRF).
+- **SurrealDB v3 correctness** — Buffered `BEGIN ... COMMIT`, unrolled `GraphQuery` depth, v3-valid `type::record()` and `FULLTEXT` indexes everywhere.
 - **`surql` CLI** — `migrate`, `schema`, `db`, `orchestrate`, `settings` subcommands (built on `@cliffy/command`).
 - **Multi-runtime** — JSR for Deno, npm for Node.js 18+.
 - **Layered settings** — env + `.env` + `surql.yaml` + `surql.toml` via `loadSettings()`.

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "lock": true,
   "name": "@oneiriq/surql",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "license": "Apache-2.0",
   "exports": {
     ".": "./mod.ts",

--- a/docs/v3-patterns.md
+++ b/docs/v3-patterns.md
@@ -96,6 +96,61 @@ typeThing('task', '123').toSurQL()  // → type::record('task:123') (same output
 
 See [Query UX](query-ux.md) for the CRUD overloads that accept these refs directly.
 
+## Full-text index renamed `SEARCH` → `FULLTEXT`
+
+SurrealDB v3 renamed the full-text index keyword. The v1/v2 form:
+
+```text
+DEFINE INDEX idx ON TABLE t FIELDS content SEARCH ANALYZER ascii BM25;  -- parse error on v3
+```
+
+is rejected (`Unexpected token, expected Eof` at `SEARCH`). v3 spells it `FULLTEXT`:
+
+```text
+DEFINE INDEX idx ON TABLE t FIELDS content FULLTEXT ANALYZER ascii BM25 HIGHLIGHTS;
+```
+
+surql emits the `FULLTEXT` keyword from `IndexType.SEARCH` / `searchIndex` / `bm25Index` (and the migration differ). The structured parser recognises **both** spellings on read, so a live definition from either server version round-trips. `COLUMNS` and `FIELDS` are interchangeable in this statement; surql emits `FIELDS`.
+
+The analyzer is defined separately with `generateAnalyzerSql` / `analyzer(...)` (`DEFINE ANALYZER ...`), which must run **before** the index that references it — `generateSchemaSql({ analyzers, tables })` emits analyzer statements ahead of tables for exactly this reason. Bare `BM25` uses the engine defaults (`k1 = 1.2`, `b = 0.75`); a full-text index with no analyzer set renders the historical `ascii` default, so define and name one explicitly for real lexical recall.
+
+```typescript
+import {
+  analyzer,
+  bm25Index,
+  generateSchemaSql,
+  standardAnalyzer,
+  TokenFilter,
+  tableSchema,
+  withFilters,
+  withIndexes,
+} from 'jsr:@oneiriq/surql'
+
+// class tokenizer + lowercase + ascii, plus English stemming.
+const textEn = withFilters(standardAnalyzer('text_en'), 'snowball(english)')
+
+const memory = withIndexes(tableSchema('memory'), bm25Index('content_bm25', ['content'], 'text_en'))
+
+generateSchemaSql({ analyzers: [textEn], tables: [memory] })
+// → DEFINE ANALYZER text_en TOKENIZERS class FILTERS lowercase,ascii,snowball(english);
+//
+//   DEFINE TABLE memory SCHEMAFULL;
+//   DEFINE INDEX content_bm25 ON TABLE memory FIELDS content FULLTEXT ANALYZER text_en BM25;
+```
+
+### `search::score` and scan ordering
+
+Run the lexical query with `Query.fulltextSearch(field, reference, query)` + `Query.searchScore(reference, alias)`, or the `fulltextSearchQuery(...)` helper:
+
+```typescript
+import { fulltextSearchQuery } from 'jsr:@oneiriq/surql'
+
+const sparse = fulltextSearchQuery('memory', 'content', 1, 'insider buying').limit(100)
+// → SELECT *, search::score(1) AS score FROM memory WHERE content @1@ 'insider buying' LIMIT 100
+```
+
+The v3 streaming executor's full-text scan yields matching rows **already in BM25 relevance order**, but does not (in 3.0.x) plumb the per-row score through to `search::score(<ref>)`, which returns `0` there. So **rank by the scan's natural order** rather than `ORDER BY search::score(...)`. This is sufficient for Reciprocal Rank Fusion, which fuses *ranks*, not raw scores: take the order the rows come back in, fuse it with the dense (`vectorSearch`) order via RRF, and you have hybrid retrieval. The query text is inlined as a single-quoted, escaped literal (no bound parameters), so a `'` in the query is escaped, not a SurrealQL injection vector.
+
 ## CI pin
 
 Integration tests run against `surrealdb/surrealdb:v3.0.5` (see `.github/workflows/integration.yml`). The publish-time unit test jobs exclude `src/test/integration*.test.ts` so JSR/npm releases do not require a live container. To run the integration tests locally:

--- a/src/migration/diff.ts
+++ b/src/migration/diff.ts
@@ -123,7 +123,9 @@ function buildIndexSql(tableName: string, idx: IndexDefinition): string {
       sql += ' UNIQUE'
       break
     case IndexType.SEARCH:
-      if (idx.searchAnalyzer) sql += ` SEARCH ANALYZER ${idx.searchAnalyzer}`
+      sql += ` FULLTEXT ANALYZER ${idx.searchAnalyzer ?? 'ascii'}`
+      if (idx.bm25) sql += ' BM25'
+      if (idx.highlights) sql += ' HIGHLIGHTS'
       break
     case IndexType.MTREE:
       sql += ` MTREE DIMENSION ${idx.mtreeDimension}`

--- a/src/query/builder.ts
+++ b/src/query/builder.ts
@@ -37,6 +37,9 @@ interface QueryState<T> {
   readonly vectorData: readonly number[] | null
   readonly vectorK: number | null
   readonly vectorDistance: VectorDistanceType | null
+  readonly fulltextField: string | null
+  readonly fulltextReference: number | null
+  readonly fulltextQuery: string | null
   readonly _phantom?: T
 }
 
@@ -62,6 +65,9 @@ function defaultState<T>(): QueryState<T> {
     vectorData: null,
     vectorK: null,
     vectorDistance: null,
+    fulltextField: null,
+    fulltextReference: null,
+    fulltextQuery: null,
   }
 }
 
@@ -190,6 +196,51 @@ export class Query<T = Record<string, unknown>> {
     })
   }
 
+  /**
+   * Configure a full-text `FULLTEXT` predicate rendered as
+   * `<field> @<reference>@ <query>` in the `WHERE` clause.
+   *
+   * The `reference` integer ties the match to a {@link searchScore} (or
+   * `search::highlight`) call, so a row's BM25 relevance can be projected and
+   * ordered on. Requires a BM25 full-text index on `field` (see `bm25Index`).
+   * The query text is inlined as a quoted, escaped literal.
+   *
+   * @example
+   * ```ts
+   * select().searchScore(1, 'score').fromTable('memory')
+   *   .fulltextSearch('content', 1, 'insider buying').orderBy('score', 'DESC').limit(10)
+   * // SELECT *, search::score(1) AS score FROM memory
+   * //   WHERE content @1@ 'insider buying' ORDER BY score DESC LIMIT 10
+   * ```
+   */
+  fulltextSearch(field: string, reference: number, query: string): Query<T> {
+    if (field.length === 0) {
+      throw new Error('Full-text search field cannot be empty')
+    }
+    if (query.length === 0) {
+      throw new Error('Full-text search query cannot be empty')
+    }
+    return this.with({
+      fulltextField: field,
+      fulltextReference: reference,
+      fulltextQuery: query,
+    })
+  }
+
+  /**
+   * Append `search::score(<reference>) AS <alias>` to the projected fields — the
+   * BM25 relevance for the match registered at `reference` by
+   * {@link fulltextSearch}. Order by `alias` to rank.
+   *
+   * When no projection has been set yet, the star is added first so the score
+   * column is appended to `SELECT *` (matching `select(None)` in the sibling
+   * ports) rather than replacing it.
+   */
+  searchScore(reference: number, alias: string): Query<T> {
+    const base = this.state.fields.length > 0 ? this.state.fields : ['*']
+    return this.with({ fields: [...base, `search::score(${reference}) AS ${alias}`] })
+  }
+
   /** Get the current operation */
   get operation(): QueryOperation {
     return this.state.operation
@@ -232,14 +283,26 @@ export class Query<T = Record<string, unknown>> {
       sql += this.state.table ? `.${this.state.traversalPath}` : ` ${this.state.traversalPath}`
     }
 
+    // Assemble WHERE parts in order: vector search, full-text match, then the
+    // accumulated raw conditions — all joined with AND.
+    const whereParts: string[] = []
     if (this.state.vectorField && this.state.vectorData) {
       const vecStr = `[${this.state.vectorData.join(', ')}]`
-      sql += ` WHERE ${this.state.vectorField} <|${this.state.vectorK ?? 10}|> ${vecStr}`
-      if (this.state.conditions.length > 0) {
-        sql += ` AND ${this.state.conditions.join(' AND ')}`
-      }
-    } else if (this.state.conditions.length > 0) {
-      sql += ` WHERE ${this.state.conditions.join(' AND ')}`
+      whereParts.push(`${this.state.vectorField} <|${this.state.vectorK ?? 10}|> ${vecStr}`)
+    }
+    if (
+      this.state.fulltextField !== null &&
+      this.state.fulltextReference !== null &&
+      this.state.fulltextQuery !== null
+    ) {
+      const quoted = quoteValue(this.state.fulltextQuery)
+      whereParts.push(`${this.state.fulltextField} @${this.state.fulltextReference}@ ${quoted}`)
+    }
+    for (const cond of this.state.conditions) {
+      whereParts.push(cond)
+    }
+    if (whereParts.length > 0) {
+      sql += ` WHERE ${whereParts.join(' AND ')}`
     }
 
     if (this.state.groupAll) {
@@ -397,4 +460,30 @@ export function similaritySearchQuery<T = Record<string, unknown>>(
   k: number = 10,
 ): Query<T> {
   return new Query<T>().select().fromTable(table).vectorSearch(field, vector, distance, k)
+}
+
+/**
+ * Create a full-text (BM25) search query — the lexical leg of hybrid retrieval.
+ *
+ * Wraps `Query.fulltextSearch` + `Query.searchScore` into
+ * `SELECT ..., search::score(reference) AS <scoreAlias> FROM <table>
+ * WHERE <field> @reference@ <query>`. Pair with a `bm25Index` on `field`, then
+ * `ORDER BY <scoreAlias> DESC` to rank by relevance.
+ */
+export function fulltextSearchQuery<T = Record<string, unknown>>(
+  table: string,
+  field: string,
+  reference: number,
+  query: string,
+  fields: string[] = [],
+  scoreAlias: string = 'score',
+): Query<T> {
+  // An empty projection becomes `*` (matching `select(None)` in the sibling
+  // ports) so the score column is appended after the star, not in place of it.
+  const projection = fields.length > 0 ? fields : ['*']
+  return new Query<T>()
+    .select(...projection)
+    .searchScore(reference, scoreAlias)
+    .fromTable(table)
+    .fulltextSearch(field, reference, query)
 }

--- a/src/query/mod.ts
+++ b/src/query/mod.ts
@@ -1,6 +1,7 @@
 export { buildRelateQuery, buildUpsertQuery, deleteMany, insertMany, relateMany, upsertMany } from './batch.ts'
 export {
   deleteQuery,
+  fulltextSearchQuery,
   insert,
   Query,
   type QueryOperation,

--- a/src/schema/analyzer.ts
+++ b/src/schema/analyzer.ts
@@ -1,0 +1,164 @@
+/**
+ * Full-text search analyzer definitions (`DEFINE ANALYZER`).
+ *
+ * A SurrealDB full-text index references an *analyzer* that turns stored text
+ * and query text into comparable tokens — the lexical side of hybrid (sparse +
+ * dense) retrieval. An analyzer is a tokenizer chain (how the text is split)
+ * followed by a filter chain (how each token is normalised).
+ *
+ * This module renders the `DEFINE ANALYZER` statement from a typed
+ * `AnalyzerDefinition`, so callers define the analyzer in code rather than
+ * hand-authoring SurrealQL — exactly as `tableSchema` does for tables. Pair it
+ * with a BM25 `searchIndex` / `bm25Index` and the `fulltextSearch` query
+ * builder for end-to-end lexical recall.
+ *
+ * @example
+ * ```ts
+ * import { analyzer, TokenFilter, Tokenizer } from './analyzer.ts'
+ *
+ * const a = withFilters(
+ *   withTokenizer(analyzer('text_en'), Tokenizer.CLASS),
+ *   TokenFilter.LOWERCASE,
+ *   TokenFilter.ASCII,
+ *   snowball('english'),
+ * )
+ * analyzerToSurql(a)
+ * // → DEFINE ANALYZER text_en TOKENIZERS class FILTERS lowercase,ascii,snowball(english);
+ * ```
+ */
+
+/**
+ * Tokenizer that splits text into terms before the filter chain runs. Each
+ * variant is the lowercase SurrealQL keyword used inside the `TOKENIZERS ...`
+ * clause.
+ */
+export enum Tokenizer {
+  /** Split on whitespace (`blank`). */
+  BLANK = 'blank',
+  /** Split on case transitions (`camelCase` → `camel`, `Case`). */
+  CAMEL = 'camel',
+  /**
+   * Split on Unicode character-class transitions — letters, digits, and
+   * punctuation become separate tokens (`class`). The general-purpose default
+   * for prose and identifiers.
+   */
+  CLASS = 'class',
+  /** Split on punctuation (`punct`). */
+  PUNCT = 'punct',
+}
+
+/**
+ * A token filter that normalises or expands each token after tokenization.
+ *
+ * The parameterless filters are members of this enum; the parameterised filters
+ * (`edgengram`, `ngram`, `snowball`) are built with the `edgeNgram`, `ngram`,
+ * and `snowball` factories, which return a `TokenFilterValue`. Filters run in
+ * declaration order.
+ */
+export enum TokenFilter {
+  /** Fold accented / Unicode characters to their nearest ASCII equivalent (`ascii`). */
+  ASCII = 'ascii',
+  /** Lowercase every token (`lowercase`). */
+  LOWERCASE = 'lowercase',
+  /** Uppercase every token (`uppercase`). */
+  UPPERCASE = 'uppercase',
+}
+
+/**
+ * A single entry in an analyzer's filter chain: either a parameterless
+ * {@link TokenFilter} keyword or a parameterised filter call rendered by
+ * {@link edgeNgram} / {@link ngram} / {@link snowball}.
+ */
+export type TokenFilterValue = TokenFilter | string
+
+/**
+ * Render an edge n-gram (prefix) filter spanning `min..=max` for prefix /
+ * typeahead matching (`edgengram(min,max)`).
+ */
+export function edgeNgram(min: number, max: number): string {
+  return `edgengram(${min},${max})`
+}
+
+/** Render an n-gram filter spanning `min..=max` (`ngram(min,max)`). */
+export function ngram(min: number, max: number): string {
+  return `ngram(${min},${max})`
+}
+
+/**
+ * Render a Snowball stemming filter for `language` (e.g. `snowball('english')`)
+ * — improves recall by matching word variants to a common stem.
+ */
+export function snowball(language: string): string {
+  return `snowball(${language})`
+}
+
+/**
+ * Immutable `DEFINE ANALYZER` schema definition: a named tokenizer + filter
+ * chain referenced by a full-text `searchIndex` / `bm25Index`.
+ */
+export interface AnalyzerDefinition {
+  /** Analyzer name (referenced by a full-text index's `ANALYZER <name>` clause). */
+  readonly name: string
+  /** Tokenizers applied, in order, to split the text. */
+  readonly tokenizers: readonly Tokenizer[]
+  /** Filters applied, in order, to normalise each token. */
+  readonly filters: readonly TokenFilterValue[]
+}
+
+/** Create a new, empty analyzer definition (no tokenizers or filters yet). */
+export function analyzer(name: string): AnalyzerDefinition {
+  return Object.freeze({ name, tokenizers: [], filters: [] })
+}
+
+/** Append one or more tokenizers to an analyzer definition. */
+export function withTokenizer(def: AnalyzerDefinition, ...tokenizers: Tokenizer[]): AnalyzerDefinition {
+  return Object.freeze({ ...def, tokenizers: [...def.tokenizers, ...tokenizers] })
+}
+
+/** Append one or more filters to an analyzer definition. */
+export function withFilters(def: AnalyzerDefinition, ...filters: TokenFilterValue[]): AnalyzerDefinition {
+  return Object.freeze({ ...def, filters: [...def.filters, ...filters] })
+}
+
+/**
+ * A sensible general-purpose analyzer for BM25 lexical recall: the `class`
+ * tokenizer with `lowercase` + `ascii` filters. Add a {@link snowball} filter
+ * via {@link withFilters} for language-specific stemming.
+ */
+export function standardAnalyzer(name: string): AnalyzerDefinition {
+  return Object.freeze({
+    name,
+    tokenizers: [Tokenizer.CLASS],
+    filters: [TokenFilter.LOWERCASE, TokenFilter.ASCII],
+  })
+}
+
+/**
+ * Validate an analyzer definition.
+ *
+ * @throws {Error} when the name is empty.
+ */
+export function validateAnalyzer(def: AnalyzerDefinition): void {
+  if (def.name.length === 0) {
+    throw new Error('Analyzer name cannot be empty')
+  }
+}
+
+/**
+ * Render the `DEFINE ANALYZER` statement.
+ *
+ * Pass `ifNotExists: true` to emit `DEFINE ANALYZER IF NOT EXISTS ...` so it can
+ * be re-applied idempotently (e.g. a persistent store applying its schema on
+ * every connect). Empty tokenizer / filter chains omit their clause entirely.
+ */
+export function analyzerToSurql(def: AnalyzerDefinition, options: { ifNotExists?: boolean } = {}): string {
+  const ine = options.ifNotExists ? 'IF NOT EXISTS ' : ''
+  let sql = `DEFINE ANALYZER ${ine}${def.name}`
+  if (def.tokenizers.length > 0) {
+    sql += ` TOKENIZERS ${def.tokenizers.join(',')}`
+  }
+  if (def.filters.length > 0) {
+    sql += ` FILTERS ${def.filters.join(',')}`
+  }
+  return sql + ';'
+}

--- a/src/schema/mod.ts
+++ b/src/schema/mod.ts
@@ -8,6 +8,21 @@ export {
   type RecordAccessConfig,
 } from './access.ts'
 export {
+  analyzer,
+  type AnalyzerDefinition,
+  analyzerToSurql,
+  edgeNgram,
+  ngram,
+  snowball,
+  standardAnalyzer,
+  TokenFilter,
+  type TokenFilterValue,
+  Tokenizer,
+  validateAnalyzer,
+  withFilters,
+  withTokenizer,
+} from './analyzer.ts'
+export {
   bidirectionalEdge,
   type EdgeDefinition,
   EdgeMode,
@@ -64,8 +79,9 @@ export {
   registerTable,
   SchemaRegistry,
 } from './registry.ts'
-export { generateAccessSql, generateEdgeSql, generateSchemaSql, generateTableSql } from './sql.ts'
+export { generateAccessSql, generateAnalyzerSql, generateEdgeSql, generateSchemaSql, generateTableSql } from './sql.ts'
 export {
+  bm25Index,
   event,
   type EventDefinition,
   HnswDistanceType,

--- a/src/schema/parser.ts
+++ b/src/schema/parser.ts
@@ -112,8 +112,9 @@ const TYPE_WORD_RE = /^([A-Za-z_][A-Za-z0-9_]*)/
  */
 const ARRAY_SUBFIELD_RE = /(?:\[\*\]|\.\*)\s*$/
 
-const COLUMNS_RE = /COLUMNS\s+([^;]+?)(?:UNIQUE|SEARCH|HNSW|MTREE|\s*;|\s*$)/i
-const FIELDS_RE = /FIELDS\s+([^;]+?)(?:UNIQUE|SEARCH|HNSW|MTREE|\s*;|\s*$)/i
+const COLUMNS_RE = /COLUMNS\s+([^;]+?)(?:UNIQUE|FULLTEXT|SEARCH|HNSW|MTREE|\s*;|\s*$)/i
+const FIELDS_RE = /FIELDS\s+([^;]+?)(?:UNIQUE|FULLTEXT|SEARCH|HNSW|MTREE|\s*;|\s*$)/i
+const ANALYZER_RE = /ANALYZER\s+(\w+)/i
 const DIMENSION_RE = /DIMENSION\s+(\d+)/i
 const DISTANCE_RE = /(?:DIST|DISTANCE)\s+(\w+)/i
 const EFC_RE = /EFC\s+(\d+)/i
@@ -423,10 +424,25 @@ function extractIndexFields(definition: string): string[] {
 function extractIndexType(definition: string): IndexType {
   const upper = definition.toUpperCase()
   if (upper.includes('UNIQUE')) return IndexType.UNIQUE
-  if (upper.includes('SEARCH')) return IndexType.SEARCH
+  // SurrealDB 3.x renamed the full-text keyword `SEARCH` → `FULLTEXT`; accept
+  // both spellings so live definitions from either server version round-trip.
+  if (upper.includes('FULLTEXT') || upper.includes('SEARCH')) return IndexType.SEARCH
   if (upper.includes('HNSW')) return IndexType.HNSW
   if (upper.includes('MTREE')) return IndexType.MTREE
   return IndexType.STANDARD
+}
+
+/**
+ * Extract the full-text `ANALYZER <name>`. The historical `ascii` default (what
+ * a plain `searchIndex` renders) normalises back to `undefined`, so a round-trip
+ * of the default form is an identity, leaving an explicit non-`ascii` analyzer
+ * as a populated string.
+ */
+function extractAnalyzer(definition: string): string | undefined {
+  const m = ANALYZER_RE.exec(definition)
+  if (!m) return undefined
+  const name = m[1]
+  return name.toLowerCase() === 'ascii' ? undefined : name
 }
 
 function extractDimension(definition: string): number | undefined {
@@ -532,7 +548,13 @@ export function parseIndex(name: string, definition: string): IndexDefinition | 
     type,
   }
 
-  if (type === IndexType.MTREE) {
+  if (type === IndexType.SEARCH) {
+    const analyzer = extractAnalyzer(definition)
+    if (analyzer !== undefined) base.searchAnalyzer = analyzer
+    const upper = definition.toUpperCase()
+    if (upper.includes('BM25')) base.bm25 = true
+    if (upper.includes('HIGHLIGHTS')) base.highlights = true
+  } else if (type === IndexType.MTREE) {
     const dim = extractDimension(definition)
     if (dim !== undefined) base.mtreeDimension = dim
     const dist = extractMtreeDistance(definition)

--- a/src/schema/sql.ts
+++ b/src/schema/sql.ts
@@ -2,6 +2,8 @@ import type { FieldDefinition } from './fields.ts'
 import { FieldType } from './fields.ts'
 import type { AccessDefinition } from './access.ts'
 import { AccessType } from './access.ts'
+import type { AnalyzerDefinition } from './analyzer.ts'
+import { analyzerToSurql, validateAnalyzer } from './analyzer.ts'
 import type { EdgeDefinition } from './edge.ts'
 import type { EventDefinition, IndexDefinition, TableDefinition } from './table.ts'
 import { IndexType } from './table.ts'
@@ -83,7 +85,9 @@ function generateIndexSql(tableName: string, idx: IndexDefinition): string {
       sql += ' UNIQUE'
       break
     case IndexType.SEARCH:
-      if (idx.searchAnalyzer) sql += ` SEARCH ANALYZER ${idx.searchAnalyzer}`
+      sql += ` FULLTEXT ANALYZER ${idx.searchAnalyzer ?? 'ascii'}`
+      if (idx.bm25) sql += ' BM25'
+      if (idx.highlights) sql += ' HIGHLIGHTS'
       break
     case IndexType.MTREE:
       sql += ` MTREE DIMENSION ${idx.mtreeDimension}`
@@ -206,12 +210,31 @@ export function generateAccessSql(
 }
 
 /**
- * Generate all schema SQL from tables, edges, and access definitions.
+ * Generate SurrealQL DDL for a `DEFINE ANALYZER` definition.
  *
- * Pass `ifNotExists: true` to propagate `IF NOT EXISTS` to every emitted
- * `DEFINE TABLE` and `DEFINE ACCESS` statement.
+ * Validates the analyzer first (a definition with an empty name throws). Pass
+ * `ifNotExists: true` to emit `DEFINE ANALYZER IF NOT EXISTS ...` for idempotent
+ * re-application.
+ *
+ * An analyzer must be defined BEFORE any full-text index that references it, so
+ * `generateSchemaSql` emits analyzer statements ahead of tables.
+ */
+export function generateAnalyzerSql(analyzer: AnalyzerDefinition, options: { ifNotExists?: boolean } = {}): string {
+  validateAnalyzer(analyzer)
+  return analyzerToSurql(analyzer, options)
+}
+
+/**
+ * Generate all schema SQL from analyzers, tables, edges, and access
+ * definitions.
+ *
+ * Analyzers render first so a full-text index can reference an analyzer defined
+ * earlier in the same script. Pass `ifNotExists: true` to propagate
+ * `IF NOT EXISTS` to every emitted `DEFINE ANALYZER` / `DEFINE TABLE` /
+ * `DEFINE ACCESS` statement.
  */
 export function generateSchemaSql(options: {
+  analyzers?: AnalyzerDefinition[]
   tables?: TableDefinition[]
   edges?: EdgeDefinition[]
   access?: AccessDefinition[]
@@ -219,6 +242,12 @@ export function generateSchemaSql(options: {
 }): string {
   const parts: string[] = []
   const emitOpts = { ifNotExists: options.ifNotExists }
+
+  if (options.analyzers) {
+    for (const a of options.analyzers) {
+      parts.push(generateAnalyzerSql(a, emitOpts))
+    }
+  }
 
   if (options.tables) {
     for (const table of options.tables) {

--- a/src/schema/table.ts
+++ b/src/schema/table.ts
@@ -62,7 +62,22 @@ export interface IndexDefinition {
   readonly name: string
   readonly fields: readonly string[]
   readonly type: IndexType
+  /**
+   * Full-text index analyzer name. Only meaningful for {@link IndexType.SEARCH}
+   * indexes; when unset the index renders the historical `ascii` analyzer.
+   */
   readonly searchAnalyzer?: string
+  /**
+   * Whether a full-text index emits the `BM25` relevance-scoring clause —
+   * required for `search::score` to return a value. Uses the engine's default
+   * `(k1, b)` parameters.
+   */
+  readonly bm25?: boolean
+  /**
+   * Whether a full-text index stores positional `HIGHLIGHTS` data (enables
+   * `search::highlight` / `search::offsets`).
+   */
+  readonly highlights?: boolean
   readonly mtreeDistance?: MTreeDistanceType
   readonly mtreeDimension?: number
   readonly mtreeVectorType?: MTreeVectorType
@@ -155,9 +170,48 @@ export function uniqueIndex(name: string, ...fields: string[]): IndexDefinition 
   return Object.freeze({ name, fields, type: IndexType.UNIQUE })
 }
 
-/** Create a search index */
-export function searchIndex(name: string, fields: string[], analyzer: string): IndexDefinition {
-  return Object.freeze({ name, fields, type: IndexType.SEARCH, searchAnalyzer: analyzer })
+/**
+ * Create a full-text search index.
+ *
+ * With no analyzer set the index renders the historical `ascii` default; pass
+ * `analyzer` (e.g. one defined via `analyzer(...)`) and the `bm25` / `highlights`
+ * options for a scorable index, or use {@link bm25Index} for the common
+ * BM25-scored shape.
+ */
+export function searchIndex(
+  name: string,
+  fields: string[],
+  analyzer?: string,
+  options: { bm25?: boolean; highlights?: boolean } = {},
+): IndexDefinition {
+  const def: {
+    name: string
+    fields: string[]
+    type: IndexType
+    searchAnalyzer?: string
+    bm25?: boolean
+    highlights?: boolean
+  } = { name, fields, type: IndexType.SEARCH }
+  if (analyzer !== undefined) def.searchAnalyzer = analyzer
+  if (options.bm25) def.bm25 = true
+  if (options.highlights) def.highlights = true
+  return Object.freeze(def)
+}
+
+/**
+ * Create a BM25-scored full-text search index over `fields`, analyzed by
+ * `analyzer`. This is the index to pair with `Query.fulltextSearch` and
+ * `Query.searchScore` for lexical recall — BM25 is what makes `search::score`
+ * return a relevance value.
+ *
+ * @example
+ * ```ts
+ * bm25Index('content_bm25', ['content'], 'text_en')
+ * // emits: DEFINE INDEX content_bm25 ON TABLE <t> FIELDS content FULLTEXT ANALYZER text_en BM25;
+ * ```
+ */
+export function bm25Index(name: string, fields: string[], analyzer: string): IndexDefinition {
+  return searchIndex(name, fields, analyzer, { bm25: true })
 }
 
 /** Create an MTREE vector index */

--- a/src/test/analyzer.test.ts
+++ b/src/test/analyzer.test.ts
@@ -1,0 +1,193 @@
+import { assertEquals, assertStringIncludes, assertThrows } from '@std/assert'
+import { describe, it } from '@std/testing/bdd'
+import {
+  analyzer,
+  analyzerToSurql,
+  edgeNgram,
+  generateAnalyzerSql,
+  generateSchemaSql,
+  ngram,
+  snowball,
+  standardAnalyzer,
+  TokenFilter,
+  Tokenizer,
+  validateAnalyzer,
+  withFilters,
+  withTokenizer,
+} from '../schema/mod.ts'
+import { bm25Index, searchIndex, tableSchema, withIndexes } from '../schema/table.ts'
+import { generateTableSql } from '../schema/sql.ts'
+
+// ---------------------------------------------------------------------------
+// Tokenizer / TokenFilter rendering
+// ---------------------------------------------------------------------------
+
+describe('Tokenizer / TokenFilter values', () => {
+  it('tokenizers render the lowercase keyword', () => {
+    assertEquals(Tokenizer.BLANK, 'blank')
+    assertEquals(Tokenizer.CAMEL, 'camel')
+    assertEquals(Tokenizer.CLASS, 'class')
+    assertEquals(Tokenizer.PUNCT, 'punct')
+  })
+
+  it('parameterless filters render their keyword', () => {
+    assertEquals(TokenFilter.ASCII, 'ascii')
+    assertEquals(TokenFilter.LOWERCASE, 'lowercase')
+    assertEquals(TokenFilter.UPPERCASE, 'uppercase')
+  })
+
+  it('parameterised filter factories render their call', () => {
+    assertEquals(edgeNgram(2, 10), 'edgengram(2,10)')
+    assertEquals(ngram(1, 3), 'ngram(1,3)')
+    assertEquals(snowball('english'), 'snowball(english)')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// AnalyzerDefinition rendering
+// ---------------------------------------------------------------------------
+
+describe('analyzer rendering', () => {
+  it('renders the name only when no tokenizers / filters', () => {
+    assertEquals(analyzerToSurql(analyzer('plain')), 'DEFINE ANALYZER plain;')
+  })
+
+  it('renders tokenizers and filters in order', () => {
+    const a = withFilters(
+      withTokenizer(analyzer('text_en'), Tokenizer.CLASS, Tokenizer.CAMEL),
+      TokenFilter.LOWERCASE,
+      TokenFilter.ASCII,
+    )
+    assertEquals(
+      analyzerToSurql(a),
+      'DEFINE ANALYZER text_en TOKENIZERS class,camel FILTERS lowercase,ascii;',
+    )
+  })
+
+  it('emits IF NOT EXISTS when requested', () => {
+    assertEquals(
+      analyzerToSurql(standardAnalyzer('std'), { ifNotExists: true }),
+      'DEFINE ANALYZER IF NOT EXISTS std TOKENIZERS class FILTERS lowercase,ascii;',
+    )
+  })
+
+  it('standardAnalyzer is class + lowercase + ascii', () => {
+    const a = standardAnalyzer('std')
+    assertEquals(a.tokenizers, [Tokenizer.CLASS])
+    assertEquals(a.filters, [TokenFilter.LOWERCASE, TokenFilter.ASCII])
+  })
+
+  it('renders a snowball stemming filter', () => {
+    const a = withFilters(standardAnalyzer('text_en'), snowball('english'))
+    assertEquals(
+      analyzerToSurql(a),
+      'DEFINE ANALYZER text_en TOKENIZERS class FILTERS lowercase,ascii,snowball(english);',
+    )
+  })
+
+  it('composes immutably', () => {
+    const base = analyzer('a')
+    const extended = withTokenizer(base, Tokenizer.CLASS)
+    assertEquals(base.tokenizers.length, 0)
+    assertEquals(extended.tokenizers.length, 1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateAnalyzer
+// ---------------------------------------------------------------------------
+
+describe('validateAnalyzer', () => {
+  it('accepts a named analyzer', () => {
+    validateAnalyzer(analyzer('ok'))
+  })
+
+  it('rejects an empty name', () => {
+    assertThrows(() => validateAnalyzer({ name: '', tokenizers: [], filters: [] }), Error, 'name')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// generateAnalyzerSql
+// ---------------------------------------------------------------------------
+
+describe('generateAnalyzerSql', () => {
+  it('renders a standard analyzer', () => {
+    assertEquals(
+      generateAnalyzerSql(standardAnalyzer('text_en')),
+      'DEFINE ANALYZER text_en TOKENIZERS class FILTERS lowercase,ascii;',
+    )
+  })
+
+  it('forwards ifNotExists', () => {
+    assertEquals(
+      generateAnalyzerSql(analyzer('plain'), { ifNotExists: true }),
+      'DEFINE ANALYZER IF NOT EXISTS plain;',
+    )
+  })
+
+  it('validates before rendering', () => {
+    assertThrows(() => generateAnalyzerSql({ name: '', tokenizers: [], filters: [] }), Error, 'name')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// bm25Index / searchIndex FULLTEXT rendering (via generateTableSql)
+// ---------------------------------------------------------------------------
+
+describe('full-text index rendering', () => {
+  it('bm25Index renders FULLTEXT ANALYZER <name> BM25', () => {
+    const t = withIndexes(tableSchema('memory'), bm25Index('content_bm25', ['content'], 'text_en'))
+    const sql = generateTableSql(t)
+    assertStringIncludes(
+      sql,
+      'DEFINE INDEX content_bm25 ON TABLE memory FIELDS content FULLTEXT ANALYZER text_en BM25;',
+    )
+  })
+
+  it('plain searchIndex falls back to the ascii analyzer', () => {
+    const t = withIndexes(tableSchema('post'), searchIndex('s', ['title', 'content']))
+    const sql = generateTableSql(t)
+    assertStringIncludes(sql, 'FULLTEXT ANALYZER ascii;')
+  })
+
+  it('searchIndex carries analyzer, BM25, and HIGHLIGHTS', () => {
+    const t = withIndexes(
+      tableSchema('doc'),
+      searchIndex('s', ['content'], 'text_en', { bm25: true, highlights: true }),
+    )
+    const sql = generateTableSql(t)
+    assertStringIncludes(
+      sql,
+      'DEFINE INDEX s ON TABLE doc FIELDS content FULLTEXT ANALYZER text_en BM25 HIGHLIGHTS;',
+    )
+  })
+
+  it('no longer emits the legacy SEARCH keyword', () => {
+    const t = withIndexes(tableSchema('post'), bm25Index('s', ['content'], 'text_en'))
+    const sql = generateTableSql(t)
+    assertEquals(/\bSEARCH\b/.test(sql), false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// generateSchemaSql emits analyzers before tables
+// ---------------------------------------------------------------------------
+
+describe('generateSchemaSql with analyzers', () => {
+  it('emits DEFINE ANALYZER ahead of the table that references it', () => {
+    const analyzers = [standardAnalyzer('text_en')]
+    const tables = [withIndexes(tableSchema('memory'), bm25Index('content_bm25', ['content'], 'text_en'))]
+    const sql = generateSchemaSql({ analyzers, tables })
+    const analyzerPos = sql.indexOf('DEFINE ANALYZER text_en')
+    const indexPos = sql.indexOf('DEFINE INDEX content_bm25')
+    assertEquals(analyzerPos >= 0, true)
+    assertEquals(indexPos >= 0, true)
+    assertEquals(analyzerPos < indexPos, true)
+  })
+
+  it('propagates ifNotExists to the analyzer statement', () => {
+    const sql = generateSchemaSql({ analyzers: [standardAnalyzer('text_en')], ifNotExists: true })
+    assertStringIncludes(sql, 'DEFINE ANALYZER IF NOT EXISTS text_en')
+  })
+})

--- a/src/test/fulltext.test.ts
+++ b/src/test/fulltext.test.ts
@@ -1,0 +1,86 @@
+import { assertEquals, assertStringIncludes, assertThrows } from '@std/assert'
+import { describe, it } from '@std/testing/bdd'
+import { fulltextSearchQuery, select } from '../query/builder.ts'
+
+// ---------------------------------------------------------------------------
+// Query.fulltextSearch + Query.searchScore
+// ---------------------------------------------------------------------------
+
+describe('Query.fulltextSearch', () => {
+  it('renders the @ref@ match operator', () => {
+    const sql = select().fromTable('memory').fulltextSearch('content', 1, 'insider buying').toSurQL()
+    assertEquals(sql, "SELECT * FROM memory WHERE content @1@ 'insider buying'")
+  })
+
+  it('projects search::score and orders by it', () => {
+    const sql = select()
+      .searchScore(1, 'score')
+      .fromTable('memory')
+      .fulltextSearch('content', 1, 'form 4')
+      .orderBy('score', 'DESC')
+      .limit(5)
+      .toSurQL()
+    assertEquals(
+      sql,
+      "SELECT *, search::score(1) AS score FROM memory WHERE content @1@ 'form 4' ORDER BY score DESC LIMIT 5",
+    )
+  })
+
+  it('single-quote escapes the query text', () => {
+    const sql = select().fromTable('memory').fulltextSearch('content', 0, "o'brien").toSurQL()
+    assertEquals(sql, "SELECT * FROM memory WHERE content @0@ 'o\\'brien'")
+  })
+
+  it('escapes a backslash before the quote (no smuggled terminator)', () => {
+    const sql = select().fromTable('memory').fulltextSearch('content', 0, 'a\\b').toSurQL()
+    assertEquals(sql, "SELECT * FROM memory WHERE content @0@ 'a\\\\b'")
+  })
+
+  it('rejects an empty field', () => {
+    assertThrows(() => select().fromTable('memory').fulltextSearch('', 1, 'x'), Error, 'field')
+  })
+
+  it('rejects an empty query', () => {
+    assertThrows(() => select().fromTable('memory').fulltextSearch('content', 1, ''), Error, 'query')
+  })
+
+  it('renders alongside a vector search joined by AND', () => {
+    const sql = select()
+      .fromTable('memory')
+      .vectorSearch('embedding', [0.1, 0.2], undefined, 5)
+      .fulltextSearch('content', 1, 'term')
+      .toSurQL()
+    assertStringIncludes(sql, 'embedding <|5|> [0.1, 0.2]')
+    assertStringIncludes(sql, "content @1@ 'term'")
+    assertStringIncludes(sql, ' AND ')
+  })
+
+  it('preserves immutability across the chain', () => {
+    const base = select().fromTable('memory')
+    const ext = base.fulltextSearch('content', 1, 'x')
+    assertEquals(base.toSurQL(), 'SELECT * FROM memory')
+    assertStringIncludes(ext.toSurQL(), "content @1@ 'x'")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// fulltextSearchQuery helper
+// ---------------------------------------------------------------------------
+
+describe('fulltextSearchQuery helper', () => {
+  it('builds SELECT *, search::score(...) ... WHERE field @ref@ query', () => {
+    const sql = fulltextSearchQuery('memory', 'content', 1, 'insider buying').toSurQL()
+    assertEquals(
+      sql,
+      "SELECT *, search::score(1) AS score FROM memory WHERE content @1@ 'insider buying'",
+    )
+  })
+
+  it('honours an explicit projection and score alias', () => {
+    const sql = fulltextSearchQuery('memory', 'content', 2, 'term', ['id', 'content'], 'relevance').toSurQL()
+    assertEquals(
+      sql,
+      "SELECT id, content, search::score(2) AS relevance FROM memory WHERE content @2@ 'term'",
+    )
+  })
+})

--- a/src/test/schema_parser.test.ts
+++ b/src/test/schema_parser.test.ts
@@ -21,6 +21,7 @@ import { AccessType } from '../schema/access.ts'
 import { EdgeMode } from '../schema/edge.ts'
 import { FieldType } from '../schema/fields.ts'
 import {
+  bm25Index,
   HnswDistanceType,
   hnswIndex,
   IndexType,
@@ -209,13 +210,27 @@ describe('parseIndex', () => {
     assertEquals(i.fields, ['a', 'b', 'c'])
   })
 
-  it('parses SEARCH index', () => {
+  it('parses legacy SEARCH index', () => {
     const i = parseIndex(
       'content_search',
       'DEFINE INDEX content_search ON TABLE post COLUMNS title, content SEARCH ANALYZER ascii',
     )!
     assertEquals(i.type, IndexType.SEARCH)
     assertEquals(i.fields.length, 2)
+    // `ascii` is the historical default — it normalises back to undefined.
+    assertEquals(i.searchAnalyzer, undefined)
+  })
+
+  it('parses FULLTEXT index with analyzer, BM25, and HIGHLIGHTS', () => {
+    const i = parseIndex(
+      'content_bm25',
+      'DEFINE INDEX content_bm25 ON TABLE memory FIELDS content FULLTEXT ANALYZER text_en BM25 HIGHLIGHTS',
+    )!
+    assertEquals(i.type, IndexType.SEARCH)
+    assertEquals(i.fields, ['content'])
+    assertEquals(i.searchAnalyzer, 'text_en')
+    assertEquals(i.bm25, true)
+    assertEquals(i.highlights, true)
   })
 
   it('parses MTREE with dimension, distance, vector type', () => {
@@ -771,6 +786,22 @@ describe('round-trip: generate → parse → regenerate', () => {
     const parsedIx = parsed.indexes[0]
     assertEquals(parsedIx.type, IndexType.SEARCH)
     assertEquals(parsedIx.fields.length, 2)
+  })
+
+  it('round-trips a bm25Index through generate + parse', () => {
+    const table = withIndexes(
+      tableSchema('memory', TableMode.SCHEMAFULL),
+      bm25Index('content_bm25', ['content'], 'text_en'),
+    )
+    const [tb, ix] = generateTableSql(table).split('\n').map((s) => s.replace(/;$/, ''))
+    // The emitter now writes the v3 FULLTEXT keyword.
+    assert(ix.includes('FULLTEXT ANALYZER text_en BM25'))
+    const parsed = parseTableInfo('memory', { tb, ix: { content_bm25: ix } })
+    const parsedIx = parsed.indexes[0]
+    assertEquals(parsedIx.type, IndexType.SEARCH)
+    assertEquals(parsedIx.fields, ['content'])
+    assertEquals(parsedIx.searchAnalyzer, 'text_en')
+    assertEquals(parsedIx.bm25, true)
   })
 })
 


### PR DESCRIPTION
Ports the full-text BM25 feature to parity with the sibling libraries (surql-rs v0.29.0, surql-py, surql-go).

**Added:** DEFINE ANALYZER builder (`analyzer`/`standardAnalyzer`, `Tokenizer`/`TokenFilter`); BM25 `FULLTEXT` index (`bm25Index`, `searchIndex(..., {bm25,highlights})`); full-text query builder (`fulltextSearch`/`searchScore` + `fulltextSearchQuery`); `generateAnalyzerSql`.
**Fixed:** SurrealDB 3.x renamed the full-text index keyword `SEARCH`→`FULLTEXT` (the old form was a parse error on v3); parser accepts both. See docs/v3-patterns.md.

Version 1.5.0 → 1.6.0. Gates: `deno check`/`deno lint` clean; `deno task test` green (one pre-existing live-DB CLI test excepted). No release in this PR.