### PR TITLE
fix(migration): portable timer type in schema watcher

### DIFF
--- a/src/migration/watcher.ts
+++ b/src/migration/watcher.ts
@@ -94,7 +94,10 @@ export async function watchSchema(
   const onError = opts.onError ?? ((e: unknown) => console.error('watchSchema error:', e))
 
   let stopped = false
-  let debounceTimer: number | undefined
+  // `ReturnType<typeof setTimeout>` rather than `number`: portable across the
+  // Deno (`number`) and Node (`Timeout`) timer typings, so type-checking passes
+  // regardless of which lib the toolchain resolves.
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined
 
   const watcher = Deno.watchFs(schemaDir, { recursive: true })
 


### PR DESCRIPTION
`debounceTimer` in `src/migration/watcher.ts` was typed `number`, but `setTimeout` resolves to `Timeout` under the Node timer typings CI's Deno pulls in — `TS2322` at watcher.ts:117 failed `deno check` / `test` on CI (it surfaced when the v1.6.0 release ran publish `verify`).

Fix: type it `ReturnType<typeof setTimeout>`, correct under both the Deno (`number`) and Node (`Timeout`) libs. Pre-existing; untouched by the full-text work.