### PR TITLE
fix(ci): always use the publish environment for publish-npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,10 @@ jobs:
       (github.event_name == 'release' && !github.event.release.prerelease) ||
       (github.event_name == 'workflow_dispatch' && (inputs.target == 'npm' || inputs.target == 'both'))
     runs-on: [self-hosted, aur0]
-    environment: ${{ github.event_name == 'release' && 'publish' || '' }}
+    # Always the `publish` environment. NPM_TOKEN lives there and nowhere
+    # else -- there is no repo- or org-level fallback -- so a run without
+    # it publishes with an empty NODE_AUTH_TOKEN and fails on auth.
+    environment: publish
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## The bug

`publish-npm` selected its environment conditionally:

```yaml
environment: ${{ github.event_name == 'release' && 'publish' || '' }}
```

On a `workflow_dispatch` run that resolves to **no environment**. `NPM_TOKEN` is stored *only* as an environment secret on `publish` -- verified there is no repo-level or organization-level fallback (`Oneiriq` org has only `ONEIRIQ_READ_PAT`). So dispatch runs reached `npm publish` with an empty `NODE_AUTH_TOKEN` and failed on auth, even though the job's `if:` explicitly permits dispatch with `target` of `npm` or `both`.

The nastier consequence is diagnostic: the release path works while the dispatch path fails for an unrelated reason. Retrying a failed release publish via manual dispatch produces an auth error that looks like the token is still wrong.

## The fix

Always use `publish`.

## Trade-off, stated explicitly

The `publish` environment has a **required-reviewer** protection rule, so dispatch runs will now wait for approval -- exactly as release runs already do today. That is the right trade: an ad-hoc publish to a public registry should be reviewed. The alternative, adding a repo-level `NPM_TOKEN` as a fallback, would duplicate the secret into a less protected scope and defeat the gate.

This also matches the sibling repos: `cosmiq-graphql` and `stoat-logger` both declare `environment: publish` unconditionally.

## Not changed

`publish-jsr` deliberately has no environment -- it authenticates to JSR via OIDC and consumes no secret.

## Context

npm publishing for this package has failed far more often than it has succeeded (10 failed release runs vs 5 successful across the tag history). Combined with GitHub's ~30-day limit on re-running a workflow run, a missed failure becomes permanent: `v1.5.0` and `v1.6.0` can no longer be published at all, because their runs are past the re-run window and dispatching against those tags would use the buggy workflow file stored at those tags. npm therefore skips from 1.4.0 to 1.7.0. This fix stops that failure mode recurring for future releases.