### PR TITLE
fix(ci): declare least-privilege permissions on the audit workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -32,6 +32,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: every step here only reads the checkout and runs npm
+# against a manifest it synthesizes itself. Without this block the job
+# inherits the repository default, which code scanning flags
+# (actions/missing-workflow-permissions).
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 


### PR DESCRIPTION
Closes the open code scanning alert `actions/missing-workflow-permissions` at `.github/workflows/audit.yml:40`.

`audit.yml` was the only workflow in the repository without a `permissions` block, so its job inherited the repository default token scope. Every step in it reads the checkout and runs `npm audit` against a manifest it synthesizes itself, so `contents: read` covers it.