### PR TITLE
chore(ci): bump pinned actions to current releases

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
 

--- a/.github/workflows/dep-review.yml
+++ b/.github/workflows/dep-review.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: moderate
           comment-summary-in-pr: on-failure

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -24,7 +24,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Wait for required checks
-        uses: lewagon/wait-on-check-action@v1.7.0
+        uses: lewagon/wait-on-check-action@v1.9.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           running-workflow-name: auto-merge

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           deno-version: v2.x
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
Supersedes the stale dependabot PRs #67, #68, and #70.

| action | dependabot proposed | this PR |
|---|---|---|
| `lewagon/wait-on-check-action` | v1.9.0 (#70) | **v1.9.1** |
| `actions/setup-node` | v6 (#67) | **v7** |
| `actions/dependency-review-action` | v5 (#68) | v5 |

Two of those PRs would land versions that are themselves now behind, and rebasing each individually costs a CI run apiece. Both `setup-node` call sites pass only `node-version` (plus `registry-url` on the publish path), which are stable inputs across the majors crossed.