### PR TITLE
chore(release): v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.8.0] - 2026-08-12
 
 ### Added
 

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "lock": true,
   "name": "@oneiriq/surql",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "license": "Apache-2.0",
   "exports": {
     ".": "./mod.ts",


### PR DESCRIPTION
Cuts 1.8.0. Four commits since v1.7.0.

## Added

DISKANN vector indexes and the F16 element type, plus `Query.vectorSearchIndexed`, which renders the integer exploration form the engine plans as a `KnnScan` over the field's index.

## Fixed

- **Vector search emitted SQL v3 refuses.** The builder rendered the bare `<|k|>` KNN form, which belongs to the KTree era and is a parse error on v3, so vector search here did not work against a v3 server at all. It also accepted a `distance` argument and dropped it.
- **The migration diff silently dropped HNSW clauses**, rendering an HNSW index as a plain index with its dimension, metric, and tuning gone. It now delegates to the schema emitter so the two cannot drift again.
- **The schema parser dropped unrecognised vector element types.**
- Least-privilege permissions on the audit workflow, closing a code scanning alert.

## Why minor, not patch

The vector surface is new. The KNN repair is a fix in the strict sense: the previous output was invalid on v3, so no caller can have depended on it.